### PR TITLE
Use ~/.vessel-cache as the cache directory for base image and application layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+* Set the directory for caching base image and application layers to
+  ~/.vessel-cache. Eventually, Vessel can take this directory as a parameter to
+  allow a more fine-grained customization.
+
 ## [0.1.84] - 2020-02-18
 
 ### Added

--- a/src/vessel/misc.clj
+++ b/src/vessel/misc.clj
@@ -117,6 +117,12 @@
   [fs]
   (filter #(.isFile %) fs))
 
+(defn ^File home-dir
+  "Returns a file object representing the home directory of the current
+  user."
+  []
+  (io/file (System/getProperty "user.home")))
+
 (defn ^File make-dir
   "Creates the directory in question and all of its parents.
 

--- a/test/vessel/misc_test.clj
+++ b/test/vessel/misc_test.clj
@@ -66,12 +66,12 @@
   (testing "prints or omits the message depending on the value bound to
   *verbose-logs* and the supplied log level"
     (are [verbose? stream level result]
-         (= result
-            (let [writer (java.io.StringWriter.)]
-              (binding [misc/*verbose-logs* verbose?
-                        stream writer]
-                (misc/log* level "me" "Hello!")
-                (str writer))))
+        (= result
+           (let [writer (java.io.StringWriter.)]
+             (binding [misc/*verbose-logs* verbose?
+                       stream writer]
+               (misc/log* level "me" "Hello!")
+               (str writer))))
       true  *out* :info  "INFO [me] Hello!\n"
       true  *out* "info" "INFO [me] Hello!\n"
       true  *out* :debug "DEBUG [me] Hello!\n"
@@ -101,6 +101,9 @@
 (deftest filter-files-test
   (is (every? #(.isFile %)
               (misc/filter-files (file-seq cwd)))))
+
+(deftest home-dir-test
+  (is (true? (misc/file-exists? (misc/home-dir)))))
 
 (deftest make-dir-test
   (let [dir (misc/make-dir (io/file "target") "tests" "misc-test" "dir1" "dir2")]

--- a/test/vessel/misc_test.clj
+++ b/test/vessel/misc_test.clj
@@ -6,7 +6,9 @@
             [clojure.test.check.properties :as prop]
             [vessel.misc :as misc]
             [vessel.test-helpers :refer [ensure-clean-test-dir]])
-  (:import [java.io StringReader StringWriter]
+  (:import com.google.cloud.tools.jib.api.AbsoluteUnixPath
+           [java.io StringReader StringWriter]
+           java.nio.file.Path
            [java.time Duration Instant]
            java.util.function.Consumer))
 
@@ -26,6 +28,12 @@
   (is (= {:a 1}
          (misc/assoc-some {}
                           :a 1 :b nil))))
+
+(deftest string->java-path-test
+  (is (instance? Path (misc/string->java-path "/"))))
+
+(deftest string->absolute-unix-path-test
+  (is (instance? AbsoluteUnixPath (misc/string->absolute-unix-path "/"))))
 
 (deftest java-consumer-test
   (is (instance? Consumer
@@ -66,12 +74,12 @@
   (testing "prints or omits the message depending on the value bound to
   *verbose-logs* and the supplied log level"
     (are [verbose? stream level result]
-        (= result
-           (let [writer (java.io.StringWriter.)]
-             (binding [misc/*verbose-logs* verbose?
-                       stream writer]
-               (misc/log* level "me" "Hello!")
-               (str writer))))
+         (= result
+            (let [writer (java.io.StringWriter.)]
+              (binding [misc/*verbose-logs* verbose?
+                        stream writer]
+                (misc/log* level "me" "Hello!")
+                (str writer))))
       true  *out* :info  "INFO [me] Hello!\n"
       true  *out* "info" "INFO [me] Hello!\n"
       true  *out* :debug "DEBUG [me] Hello!\n"


### PR DESCRIPTION
Set the directory for caching base image and application layers to
  ~/.vessel-cache. Eventually, Vessel can take this directory as a parameter to
  allow a more fine-grained customization.