### PR TITLE
Add --preserve-file-permissions flag to containerize command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Added the `--preserve-file-permissions` flag to the `containerize` command. By
+  default, files are copied to the container with the permissions 644. When this
+  flag is enabled, Vessel copies files with their original permissions. This
+  feature is useful, for instance, to keep executable scripts (e.g. wrappers for
+  calling the java command) with their original permissions within the
+  container.
+
 ## [0.2.99] - 2020-03-02
 
 ### Added

--- a/src/vessel/misc.clj
+++ b/src/vessel/misc.clj
@@ -4,7 +4,7 @@
             [clojure.java.io :as io]
             [clojure.string :as string])
   (:import java.io.File
-           [java.nio.file Path Paths]
+           [java.nio.file Files LinkOption Path Paths]
            java.security.MessageDigest
            java.text.DecimalFormat
            [java.time Duration Instant]
@@ -142,6 +142,14 @@
     (when (file-exists? dir)
       (run! #(io/delete-file %) (reverse (file-seq dir))))
     (make-dir dir)))
+
+(defn posix-file-permissions
+  "Returns a set containing posix file permissions for the supplied
+  file."
+  [^File file]
+  (->> (Files/getPosixFilePermissions (.toPath file)        (make-array LinkOption 0))
+       (map str)
+       set))
 
 (defn ^File relativize
   "Given a file and a base directory, returns a new file representing

--- a/src/vessel/misc.clj
+++ b/src/vessel/misc.clj
@@ -118,6 +118,11 @@
   []
   (io/file (System/getProperty "user.home")))
 
+(defn ^Instant last-modified-time
+  "Returns the file's last modified time as a java.time.Instant."
+  [^File file]
+  (.toInstant (Files/getLastModifiedTime (.toPath file) (make-array LinkOption 0))))
+
 (defn ^File make-dir
   "Creates the directory in question and all of its parents.
 

--- a/src/vessel/program.clj
+++ b/src/vessel/program.clj
@@ -66,6 +66,9 @@
              :default cwd
              :parse-fn io/file
              :validate cli/file-or-dir-must-exist]
+            ["-P" "--preserve-file-permissions"
+             :id :preserve-file-permissions?
+             :desc "Preserve original file permissions when copying files to the container. If not enabled, the default permissions for files are 644"]
             ["-s" "--source-path PATH"
              :id :source-paths
              :desc "Directories containing source files. This option can be repeated many times"

--- a/test/vessel/image_test.clj
+++ b/test/vessel/image_test.clj
@@ -2,7 +2,10 @@
   (:require [clojure.java.io :as io]
             [clojure.test :refer :all]
             [matcher-combinators.test :refer [match?]]
-            [vessel.image :as image]))
+            [mockfn.macros :refer [providing]]
+            [vessel.image :as image]
+            [vessel.misc :as misc])
+  (:import java.io.File))
 
 (deftest internal-dep?-test
   (let [m2          (io/file "/home/builder/.m2/repository")
@@ -36,95 +39,152 @@
       true?  (io/file more-sources "my_app/misc.clj") #{sources more-sources})))
 
 (deftest render-image-spec-test
-  (let [target-dir  (io/file "/home/builder/projects/my-app/.vessel")
-        web-inf-dir (io/file target-dir "WEB-INF")
-        project-dir (io/file "/home/builder/projects/my-app")
-        m2-dir      (io/file "/home/builder/.m2/repository")
-        app         #:app {:classes
-                           {(io/file web-inf-dir "classes/my_app/server.class")         (io/file project-dir "src")
-                            (io/file web-inf-dir "classes/config.edn")                  (io/file project-dir "resources")
-                            (io/file web-inf-dir "classes/my_company/core__init.class") (io/file m2-dir "my-company/my-company/1.0.0/my-company-1.0.0.jar")}
-                           :lib [(io/file web-inf-dir "lib/aws-java-sdk-1.11.602.jar")]}
-        options     {:app-root         (io/file "/opt/app")
-                     :internal-deps-re #{#"my-company.*\.jar$"}
-                     :resource-paths   #{(io/file project-dir "resources")}
-                     :source-paths     [(io/file project-dir "src")]
-                     :manifest
-                     {:base-image
-                      {:image {:repository "jetty" :registry "my-company.com" :tag "v1"}}
-                      :image {:repository "my-app" :registry "my-company.com" :tag "v2"}}
-                     :tarball          (io/file "my-app.tar")
-                     :target-dir       target-dir}]
+  (let [target-dir        (io/file "/home/builder/projects/my-app/.vessel")
+        web-inf-dir       (io/file target-dir "WEB-INF")
+        project-dir       (io/file "/home/builder/projects/my-app")
+        m2-dir            (io/file "/home/builder/.m2/repository")
+        app               #:app {:classes
+                                 {(io/file web-inf-dir "classes/my_app/server.class")         (io/file project-dir "src")
+                                  (io/file web-inf-dir "classes/config.edn")                  (io/file project-dir "resources")
+                                  (io/file web-inf-dir "classes/my_company/core__init.class") (io/file m2-dir "my-company/my-company/1.0.0/my-company-1.0.0.jar")}
+                                 :lib [(io/file web-inf-dir "lib/aws-java-sdk-1.11.602.jar")]}
+        options           {:app-root         (io/file "/opt/app")
+                           :internal-deps-re #{#"my-company.*\.jar$"}
+                           :resource-paths   #{(io/file project-dir "resources")}
+                           :source-paths     [(io/file project-dir "src")]
+                           :manifest
+                           {:base-image
+                            {:image {:repository "jetty" :registry "my-company.com" :tag "v1"}}
+                            :image {:repository "my-app" :registry "my-company.com" :tag "v2"}}
+                           :tarball          (io/file "my-app.tar")
+                           :target-dir       target-dir}
+        modification-time (misc/now)]
+    (providing [(misc/last-modified-time (partial instance? File)) modification-time]
 
-    (testing "takes an options map and returns a map representing an image spec
+               (testing "takes an options map and returns a map representing an image spec
   for the files in question"
-      (is (= #:image{:from
-                     #:image   {:registry "my-company.com" :repository "jetty" :tag "v1"}
-                     :name
-                     #:image   {:registry "my-company.com" :repository "my-app" :tag "v2"}
-                     :layers
-                     [#:image.layer{:name   "external-deps"
-                                    :files
-                                    [#:image.layer{:source "/home/builder/projects/my-app/.vessel/WEB-INF/lib/aws-java-sdk-1.11.602.jar"
-                                                   :target "/opt/app/WEB-INF/lib/aws-java-sdk-1.11.602.jar"}]
-                                    :churn 1}
-                      #:image.layer{:name   "internal-deps"
-                                    :files
-                                    [#:image.layer{:source "/home/builder/projects/my-app/.vessel/WEB-INF/classes/my_company/core__init.class"
-                                                   :target "/opt/app/WEB-INF/classes/my_company/core__init.class"}]
-                                    :churn 3}
-                      #:image.layer{:name   "resources"
-                                    :files
-                                    [#:image.layer{:source "/home/builder/projects/my-app/.vessel/WEB-INF/classes/config.edn"
-                                                   :target "/opt/app/WEB-INF/classes/config.edn"}]
-                                    :churn 5}
-                      #:image.layer{:name   "sources"
-                                    :files
-                                    [#:image.layer{:source "/home/builder/projects/my-app/.vessel/WEB-INF/classes/my_app/server.class"
-                                                   :target "/opt/app/WEB-INF/classes/my_app/server.class"}]
-                                    :churn 7}]
-                     :tar-path "my-app.tar"}
-             (image/render-image-spec app options))))
+                 (is (= #:image{:from
+                                #:image   {:registry "my-company.com" :repository "jetty" :tag "v1"}
+                                :name
+                                #:image   {:registry "my-company.com" :repository "my-app" :tag "v2"}
+                                :layers
+                                [#:image.layer{:name  "external-deps"
+                                               :entries
+                                               [#:layer.entry{:source            "/home/builder/projects/my-app/.vessel/WEB-INF/lib/aws-java-sdk-1.11.602.jar"
+                                                              :target            "/opt/app/WEB-INF/lib/aws-java-sdk-1.11.602.jar"
+                                                              :modification-time modification-time}]
+                                               :churn 1}
+                                 #:image.layer{:name  "internal-deps"
+                                               :entries
+                                               [#:layer.entry{:source            "/home/builder/projects/my-app/.vessel/WEB-INF/classes/my_company/core__init.class"
+                                                              :target            "/opt/app/WEB-INF/classes/my_company/core__init.class"
+                                                              :modification-time modification-time}]
+                                               :churn 3}
+                                 #:image.layer{:name  "resources"
+                                               :entries
+                                               [#:layer.entry{:source            "/home/builder/projects/my-app/.vessel/WEB-INF/classes/config.edn"
+                                                              :target            "/opt/app/WEB-INF/classes/config.edn"
+                                                              :modification-time modification-time}]
+                                               :churn 5}
+                                 #:image.layer{:name  "sources"
+                                               :entries
+                                               [#:layer.entry{:source            "/home/builder/projects/my-app/.vessel/WEB-INF/classes/my_app/server.class"
+                                                              :target            "/opt/app/WEB-INF/classes/my_app/server.class"
+                                                              :modification-time modification-time}]
+                                               :churn 7}]
+                                :tar-path "my-app.tar"}
+                        (image/render-image-spec app options))))
 
-    (testing "accepts a set of extra-paths that will beget extra layers"
-      (is (match? #:image{:layers
-                          [#:image.layer{:name "extra-files-1"
-                                         :files [#:image.layer{:source "/home/builder/logback.xml"
-                                                               :target "/opt/app/WEB-INF/classes/logback.xml"}
-                                                 #:image.layer{:source "/home/builder/web.xml"
-                                                               :target "/opt/app/web.xml"}]
-                                         :churn 0}
-                           #:image.layer{:name   "external-deps"
-                                         :files
-                                         [#:image.layer{:source "/home/builder/projects/my-app/.vessel/WEB-INF/lib/aws-java-sdk-1.11.602.jar"
-                                                        :target "/opt/app/WEB-INF/lib/aws-java-sdk-1.11.602.jar"}]
-                                         :churn 1}
-                           #:image.layer{:name   "internal-deps"
-                                         :files
-                                         [#:image.layer{:source "/home/builder/projects/my-app/.vessel/WEB-INF/classes/my_company/core__init.class"
-                                                        :target "/opt/app/WEB-INF/classes/my_company/core__init.class"}]
-                                         :churn 3}
-                           #:image.layer{:name   "resources"
-                                         :files
-                                         [#:image.layer{:source "/home/builder/projects/my-app/.vessel/WEB-INF/classes/config.edn"
-                                                        :target "/opt/app/WEB-INF/classes/config.edn"}]
-                                         :churn 5}
-                           #:image.layer{:name   "sources"
-                                         :files
-                                         [#:image.layer{:source "/home/builder/projects/my-app/.vessel/WEB-INF/classes/my_app/server.class"
-                                                        :target "/opt/app/WEB-INF/classes/my_app/server.class"}]
-                                         :churn 7}
-                           #:image.layer{:name "extra-files-2"
-                                         :files [#:image.layer{:source "/home/builder/context.xml"
-                                                               :target "/opt/app/context.xml"}]
-                                         :churn 8}]}
-                  (image/render-image-spec app (assoc options :extra-paths
-                                                      #{{:source (io/file "/home/builder/logback.xml")
-                                                         :target (io/file "/opt/app/WEB-INF/classes/logback.xml")
-                                                         :churn 0}
-                                                        {:source (io/file "/home/builder/web.xml")
-                                                         :target (io/file "/opt/app/web.xml")
-                                                         :churn 0}
-                                                        {:source (io/file "/home/builder/context.xml")
-                                                         :target (io/file "/opt/app/context.xml")
-                                                         :churn 8}})))))))
+               (testing "accepts a set of extra-paths that will beget extra layers"
+                 (is (= [#:image.layer{:name    "extra-files-1"
+                                       :entries [#:layer.entry{:source            "/home/builder/logback.xml"
+                                                               :target            "/opt/app/WEB-INF/classes/logback.xml"
+                                                               :modification-time modification-time}
+                                                 #:layer.entry{:source            "/home/builder/web.xml"
+                                                               :target            "/opt/app/web.xml"
+                                                               :modification-time modification-time}]
+                                       :churn   0}
+                         #:image.layer{:name  "external-deps"
+                                       :entries
+                                       [#:layer.entry{:source            "/home/builder/projects/my-app/.vessel/WEB-INF/lib/aws-java-sdk-1.11.602.jar"
+                                                      :target            "/opt/app/WEB-INF/lib/aws-java-sdk-1.11.602.jar"
+                                                      :modification-time modification-time}]
+                                       :churn 1}
+                         #:image.layer{:name  "internal-deps"
+                                       :entries
+                                       [#:layer.entry{:source            "/home/builder/projects/my-app/.vessel/WEB-INF/classes/my_company/core__init.class"
+                                                      :target            "/opt/app/WEB-INF/classes/my_company/core__init.class"
+                                                      :modification-time modification-time}]
+                                       :churn 3}
+                         #:image.layer{:name  "resources"
+                                       :entries
+                                       [#:layer.entry{:source            "/home/builder/projects/my-app/.vessel/WEB-INF/classes/config.edn"
+                                                      :target            "/opt/app/WEB-INF/classes/config.edn"
+                                                      :modification-time modification-time}]
+                                       :churn 5}
+                         #:image.layer{:name  "sources"
+                                       :entries
+                                       [#:layer.entry{:source            "/home/builder/projects/my-app/.vessel/WEB-INF/classes/my_app/server.class"
+                                                      :target            "/opt/app/WEB-INF/classes/my_app/server.class"
+                                                      :modification-time modification-time}]
+                                       :churn 7}
+                         #:image.layer{:name  "extra-files-2"
+                                       :entries
+                                       [#:layer.entry{:source            "/home/builder/context.xml"
+                                                      :target            "/opt/app/context.xml"
+                                                      :modification-time modification-time}]
+                                       :churn 8}]
+                        (:image/layers (image/render-image-spec app (assoc options :extra-paths
+                                                                           #{{:source (io/file "/home/builder/logback.xml")
+                                                                              :target (io/file "/opt/app/WEB-INF/classes/logback.xml")
+                                                                              :churn  0}
+                                                                             {:source (io/file "/home/builder/web.xml")
+                                                                              :target (io/file "/opt/app/web.xml")
+                                                                              :churn  0}
+                                                                             {:source (io/file "/home/builder/context.xml")
+                                                                              :target (io/file "/opt/app/context.xml")
+                                                                              :churn  8}}))))))
+
+               (testing "when the key :preserve-file-permissions? is set to true, assoc's
+    the original posix file permissions of the files that will be copied to the
+    container"
+                 (let [file-permissions #{"OTHERS_READ"
+                                          "OWNER_WRITE"
+                                          "OWNER_READ"
+                                          "GROUP_READ"}]
+                   (providing [(misc/posix-file-permissions #(instance? File %)) file-permissions]
+                              (is (match? #:image{:layers
+                                                  [#:image.layer{:name    "extra-files-1"
+                                                                 :entries [#:layer.entry{:source           "/home/builder/run-app.sh"
+                                                                                         :target           "/usr/local/bin/run-app"
+                                                                                         :file-permissions file-permissions}]
+                                                                 :churn   0}
+                                                   #:image.layer{:name  "external-deps"
+                                                                 :entries
+                                                                 [#:layer.entry{:source           "/home/builder/projects/my-app/.vessel/WEB-INF/lib/aws-java-sdk-1.11.602.jar"
+                                                                                :target           "/opt/app/WEB-INF/lib/aws-java-sdk-1.11.602.jar"
+                                                                                :file-permissions file-permissions}]
+                                                                 :churn 1}
+                                                   #:image.layer{:name  "internal-deps"
+                                                                 :entries
+                                                                 [#:layer.entry{:source           "/home/builder/projects/my-app/.vessel/WEB-INF/classes/my_company/core__init.class"
+                                                                                :target           "/opt/app/WEB-INF/classes/my_company/core__init.class"
+                                                                                :file-permissions file-permissions}]
+                                                                 :churn 3}
+                                                   #:image.layer{:name  "resources"
+                                                                 :entries
+                                                                 [#:layer.entry{:source           "/home/builder/projects/my-app/.vessel/WEB-INF/classes/config.edn"
+                                                                                :target           "/opt/app/WEB-INF/classes/config.edn"
+                                                                                :file-permissions file-permissions}]
+                                                                 :churn 5}
+                                                   #:image.layer{:name  "sources"
+                                                                 :entries
+                                                                 [#:layer.entry{:source           "/home/builder/projects/my-app/.vessel/WEB-INF/classes/my_app/server.class"
+                                                                                :target           "/opt/app/WEB-INF/classes/my_app/server.class"
+                                                                                :file-permissions file-permissions}]
+                                                                 :churn 7}]}
+                                          (image/render-image-spec app (assoc options :extra-paths
+                                                                              #{{:source (io/file "/home/builder/run-app.sh")
+                                                                                 :target (io/file "/usr/local/bin/run-app")
+                                                                                 :churn  0}}
+                                                                              :preserve-file-permissions? true))))))))))

--- a/test/vessel/jib/containerizer_test.clj
+++ b/test/vessel/jib/containerizer_test.clj
@@ -23,16 +23,22 @@
 
 (deftest ^:integration containerize-test
   (testing "calls Google Jib and containerize the files in question"
-    (binding [misc/*verbose-logs* true]
-      (jib.containerizer/containerize #:image{:from
-                                              #:image   {:repository "openjdk" :tag "sha256:1fd5a77d82536c88486e526da26ae79b6cd8a14006eb3da3a25eb8d2d682ccd6"}
-                                              :name
-                                              #:image   {:repository "nubank/my-app" :tag "v1"}
-                                              :layers
-                                              [#:image.layer{:name  "resources"
-                                                             :files [#:image.layer{:source "test/resources/greeting/greeting.txt"
-                                                                                   :target "/opt/app/WEB-INF/classes/greeting.txt"}]}]
-                                              :tar-path tar-path}))
+    (let [greeting-file (io/file "test/resources/greeting/greeting.txt")]
+      (binding [misc/*verbose-logs* true]
+        (jib.containerizer/containerize #:image{:from
+                                                #:image   {:repository "openjdk" :tag "sha256:1fd5a77d82536c88486e526da26ae79b6cd8a14006eb3da3a25eb8d2d682ccd6"}
+                                                :name
+                                                #:image   {:repository "nubank/my-app" :tag "v1"}
+                                                :layers
+                                                [#:image.layer{:name    "resources"
+                                                               :entries [#:layer.entry{:source            (.getPath greeting-file)
+                                                                                       :target            "/opt/app/WEB-INF/classes/greeting.txt"
+                                                                                       :file-permissions  #{"OTHERS_READ"
+                                                                                                            "OWNER_WRITE"
+                                                                                                            "OWNER_READ"
+                                                                                                            "GROUP_READ"}
+                                                                                       :modification-time (misc/last-modified-time greeting-file)}]}]
+                                                :tar-path tar-path})))
 
     (is (true? (misc/file-exists? (io/file tar-path)))))
 
@@ -42,5 +48,5 @@
                 (m/in-any-order ["8e3ba11ec2a2b39ab372c60c16b421536e50e5ce64a0bc81765c2e38381bcff6.tar.gz"
                                  "311ad0da45338842480bf25c6e6b7bb133b7b8cf709c3470db171ec370da5539.tar.gz"
                                  "df312c74ce16f20eeb87b5640db9b1579a53534bd3e9f3de1e916fc62744bcf4.tar.gz"
-                                 "108da0866e722ecc9d139c46cc829d5714b2d047c841ba8c3685bead78037675.tar.gz"])}]
+                                 "b57174a841843f24eb730afc0ea8829ccbc7845d8619065bf7565c0c68ea81fb.tar.gz"])}]
               (misc/read-json (read-from-tarball "manifest.json")))))

--- a/test/vessel/misc_test.clj
+++ b/test/vessel/misc_test.clj
@@ -126,6 +126,13 @@
       (is (true? (misc/file-exists? new-dir)))
       (is (empty? (.listFiles new-dir))))))
 
+(deftest posix-file-permissions-test
+  (is (= #{"OTHERS_READ"
+           "OWNER_WRITE"
+           "OWNER_READ"
+           "GROUP_READ"}
+         (misc/posix-file-permissions (io/file "deps.edn")))))
+
 (deftest relativize-test
   (is (= (io/file "deps.edn")
          (misc/relativize (io/file cwd "deps.edn") cwd))))

--- a/test/vessel/misc_test.clj
+++ b/test/vessel/misc_test.clj
@@ -109,6 +109,10 @@
 (deftest home-dir-test
   (is (true? (misc/file-exists? (misc/home-dir)))))
 
+(deftest last-modified-time-test
+  (is (instance? Instant
+                 (misc/last-modified-time (io/file "deps.edn")))))
+
 (deftest make-dir-test
   (let [dir (misc/make-dir (io/file "target") "tests" "misc-test" "dir1" "dir2")]
     (is (true? (misc/file-exists? dir)))))


### PR DESCRIPTION
The `--preserve-file-permissions (-P)` flag is an opt-in to copy files with
their original permissions to the container. By default, Vessel copies files
using the value of the constant `DEFAULT_FILE_PERMISSIONS` of
`com.google.cloud.tools.jib.api.FilePermissions` class, which represents
644 (owner can read and write whereas group and others can read).

This feature is useful for keeping executable scripts (e.g. wrappers for the
java command) with their original permissions within the container.