### PR TITLE
Add native support to access Amazon Elastic Container Registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- [#10](https://github.com/nubank/vessel/pull/10): added out of the box
+  integration with Amazon Elastic Container Registry. Vessel looks up
+  credentials to access AWS API the same way the `awscli` or `Java SDK`
+  do. Thus, Vessel is capable of obtaining credentials to access `ECR`
+  repositories through instance profiles without additional configurations, what
+  might be useful to eliminate extra steps on CI pipelines.
+
 ## [0.2.126] - 2020-05-21
 
 ### Added

--- a/deps.edn
+++ b/deps.edn
@@ -1,13 +1,16 @@
 {:paths ["src" "resources"]
  :deps
- {org.clojure/clojure #:mvn{:version "1.10.0"}
-  org.clojure/core.async #:mvn{:version "1.0.567"}
-  org.clojure/data.json #:mvn{:version "0.2.6"}
+ {org.clojure/data.json #:mvn{:version "0.2.6"}
+  org.clojure/clojure #:mvn{:version "1.10.0"}
+  com.cognitect.aws/api #:mvn{:version "0.8.456"}
+  com.cognitect.aws/endpoints #:mvn{:version "1.1.11.789"}
   org.clojure/tools.cli #:mvn{:version "0.4.2"}
   org.clojure/tools.namespace #:mvn{:version "0.3.1"}
-  com.google.cloud.tools/jib-core #:mvn{:version "0.13.0"}
+  com.cognitect.aws/ecr #:mvn{:version "798.2.678.0"}
+  progrock #:mvn{:version "0.1.2"}
   clj-commons/spinner #:mvn{:version "0.6.0"}
-  progrock #:mvn{:version "0.1.2"}}
+  com.google.cloud.tools/jib-core #:mvn{:version "0.13.0"}
+  org.clojure/core.async #:mvn{:version "1.0.567"}}
  :aliases
  {:dev
   {:extra-paths ["dev/resources" "test/unit" "test/integration"]
@@ -16,6 +19,6 @@
     {:git/url "https://github.com/cognitect-labs/test-runner.git"
      :sha "cb96e80f6f3d3b307c59cbeb49bb0dcb3a2a780b"}
     org.clojure/test.check #:mvn{:version "0.10.0-RC1"}
-    mockfn #:mvn{:version "0.5.0"}
+    nubank/mockfn #:mvn{:version "0.6.1"}
     org.apache.commons/commons-vfs2 #:mvn{:version "2.4.1"}
     nubank/matcher-combinators #:mvn{:version "1.2.5"}}}}}

--- a/src/vessel/jib/containerizer.clj
+++ b/src/vessel/jib/containerizer.clj
@@ -1,6 +1,7 @@
 (ns vessel.jib.containerizer
   "Containerization API built on top of Google Jib."
-  (:require [vessel.jib.helpers :as jib.helpers]
+  (:require [vessel.jib.credentials :as credentials]
+            [vessel.jib.helpers :as jib.helpers]
             [vessel.misc :as misc])
   (:import [com.google.cloud.tools.jib.api Containerizer FilePermissions ImageFormat ImageReference Jib JibContainerBuilder LayerConfiguration LayerConfiguration$Builder LayerEntry LogEvent RegistryImage TarImage]
            com.google.cloud.tools.jib.event.events.ProgressEvent
@@ -69,7 +70,7 @@
   "Given an ImageReference instance, returns a new registry image
   object."
   [^ImageReference image-reference]
-  (let [^CredentialRetriever retriever (jib.helpers/make-docker-config-retriever image-reference)]
+  (let [^CredentialRetriever retriever (credentials/retriever-chain image-reference)]
     (.. RegistryImage (named image-reference)
         (addCredentialRetriever retriever))))
 

--- a/src/vessel/jib/credentials.clj
+++ b/src/vessel/jib/credentials.clj
@@ -1,0 +1,108 @@
+(ns vessel.jib.credentials
+  (:require [clojure.string :as string]
+            [cognitect.aws.client.api :as aws]
+            [vessel.jib.helpers :as jib.helpers])
+  (:import [com.google.cloud.tools.jib.api Credential CredentialRetriever ImageReference]
+           com.google.cloud.tools.jib.frontend.CredentialRetrieverFactory
+           com.google.cloud.tools.jib.registry.credentials.CredentialRetrievalException
+           [java.util Base64 Base64$Decoder Optional]))
+
+(def ^:private ecr-url #"^(\d+)\.dkr.ecr\.([^\.]+)\..*")
+
+(defn- account-id-and-region
+  "Given an ImageReference object, returns the Amazon account id and the
+  region where the registry lives."
+  [^ImageReference image-reference]
+  (let [registry (.getRegistry image-reference)]
+    (some->> registry
+             (re-matches ecr-url)
+             rest
+             (zipmap [:account-id :region]))))
+
+(defn- check-authentication-error
+  "Throws a CredentialRetrievalException when the response returned by
+  aws-api contains Cognitect anomalies."
+  [response]
+  (if-not (:cognitect.anomalies/category response)
+    response
+    (throw (CredentialRetrievalException.
+            (ex-info "Unable to authenticate on Amazon ECR" response)))))
+
+(defn- get-ecr-authorization-token
+  "Given an ImageReference object, calls the ECR API to obtain an
+  authorization token that, presumably, grants access to pull and/or
+  push images from/to the registry in question."
+  [^ImageReference image-reference]
+  (let [{:keys [account-id region]} (account-id-and-region image-reference)
+        client                      (aws/client {:api    :ecr
+                                                 :region region})]
+    (-> (aws/invoke client {:op      :GetAuthorizationToken
+                            :request {:registryIds [account-id]}})
+        check-authentication-error
+        :authorizationData
+        first
+        :authorizationToken)))
+
+(defn get-ecr-credential
+  "Given an ImageReference object, calls the ECR API and returns a map
+  containing the keys :username and :password representing a
+  credential to access the ECR registry in question."
+  [^ImageReference image-reference]
+  (let [^Base64$Decoder decoder       (Base64/getDecoder)
+        ^String username-and-password (->> (get-ecr-authorization-token image-reference)
+                                           (.decode decoder)
+                                           (String.))]
+    (zipmap [:username :password] (string/split username-and-password #":"))))
+
+(defn- ecr-registry?
+  "True if the ImageReference is associated to an ECR registry."
+  [^ImageReference image-reference]
+  (re-find ecr-url (.getRegistry image-reference)))
+
+(defn ^CredentialRetriever ecr-credential-retriever
+  "Returns an instance of Credentialretriever interface that attempts to
+  retrieve credential from Amazon Elastic Container Registry.
+
+  If the supplied ImageReference isn't related to ECR, returns
+  Optional/empty. Otherwise, attempts to retrieve the credential by
+  calling the ECR API. Credentials to interact with Amazon API are
+  obtained through the same chain supported by awscli or AWS SDK."
+  [^ImageReference image-reference]
+  (reify CredentialRetriever
+    (retrieve [this]
+      (if-not (ecr-registry? image-reference)
+        (Optional/empty)
+        (let [{:keys [username password]} (get-ecr-credential image-reference)]
+          (Optional/of (Credential/from username password)))))))
+
+(defn ^CredentialRetriever docker-config-retriever
+  "Returns an instance of the CredentialRetriever interface that
+  retrieves credentials from the Docker config."
+  [^ImageReference image-reference]
+  (.. CredentialRetrieverFactory
+      (forImage image-reference (jib.helpers/log-event-handler "vessel.jib.helpers"))
+      dockerConfig))
+
+(def ^:private default-retrievers
+  [ecr-credential-retriever
+   docker-config-retriever])
+
+(defn ^CredentialRetriever retriever-chain
+  "Returns an instance of Credentialretriever interface that attempts to
+  retrieve credentials to deal with the supplied image by calling a
+  chain of credential retrievers.
+
+  The argument retrievers is a sequence of 1-arity functions that take
+  an ImageReference and returns a CredentialRetriever. If omitted, the
+  default chain (ECR and Docker config) will be assumed"
+  ([^ImageReference image-reference]
+   (retriever-chain image-reference default-retrievers))
+  ([^ImageReference image-reference retrievers]
+   (reify CredentialRetriever
+     (retrieve [this]
+       (or (some (fn [retriever]
+                   (let [^Credential credential (.. (retriever  image-reference) retrieve)]
+                     (when (.isPresent credential)
+                       credential)))
+                 retrievers)
+           (Optional/empty))))))

--- a/src/vessel/jib/helpers.clj
+++ b/src/vessel/jib/helpers.clj
@@ -1,9 +1,8 @@
 (ns vessel.jib.helpers
   "Helper functions for dealing with orthogonal features of Google Jib."
   (:require [vessel.misc :as misc])
-  (:import [com.google.cloud.tools.jib.api AbsoluteUnixPath CredentialRetriever ImageReference]
+  (:import com.google.cloud.tools.jib.api.AbsoluteUnixPath
            com.google.cloud.tools.jib.event.events.ProgressEvent
-           com.google.cloud.tools.jib.frontend.CredentialRetrieverFactory
            com.google.cloud.tools.jib.tar.TarExtractor
            java.io.File))
 
@@ -26,14 +25,6 @@
                                    (* (.. progress-event getAllocation getFractionOfRoot)
                                       (.getUnits progress-event)
                                       100)))))
-
-(defn ^CredentialRetriever make-docker-config-retriever
-  "Returns an instance of a CredentialRetriever for retrieving
-  credentials from Docker config."
-  [^ImageReference image-reference]
-  (.. CredentialRetrieverFactory
-      (forImage image-reference (log-event-handler "vessel.jib.helpers"))
-      dockerConfig))
 
 (defn extract-tarball
   "Extracts the tarball into the specified destination."

--- a/src/vessel/jib/pusher.clj
+++ b/src/vessel/jib/pusher.clj
@@ -4,6 +4,7 @@
             [clojure.data.json :as json]
             [clojure.java.io :as io]
             [progrock.core :as progrock]
+            [vessel.jib.credentials :as credentials]
             [vessel.jib.helpers :as jib.helpers]
             [vessel.misc :as misc])
   (:import [com.google.cloud.tools.jib.api DescriptorDigest ImageReference LogEvent]
@@ -58,7 +59,7 @@
                                            anonymous?                 false}}]
   (let [^Credential credential
         (when-not anonymous?
-          (.. (jib.helpers/make-docker-config-retriever image-reference) retrieve get))
+          (.. (credentials/retriever-chain image-reference) retrieve get))
         ^FailoverHttpClient http-client (FailoverHttpClient. allow-insecure-registries? (not anonymous?) (jib.helpers/log-event-handler "vessel.jib.pusher"))
         ^EventHandlers event-handlers   (make-event-handlers)
         ^RegistryClient client

--- a/test/unit/vessel/jib/pusher_test.clj
+++ b/test/unit/vessel/jib/pusher_test.clj
@@ -4,7 +4,7 @@
             [clojure.test :refer :all]
             [mockfn.macros :refer [calling providing verifying]]
             [mockfn.matchers :refer [a any exactly pred]]
-            [vessel.jib.helpers :as jib.helpers]
+            [vessel.jib.credentials :as credentials]
             [vessel.jib.pusher :as pusher]
             [vessel.test-helpers :refer [ensure-clean-test-dir]])
   (:import [com.google.cloud.tools.jib.api Credential CredentialRetriever DescriptorDigest ImageReference]
@@ -23,14 +23,14 @@
 (deftest make-registry-client-test
   (testing "by default, attempts to retrieve credentials and to authenticate on
   the registry"
-    (verifying [(jib.helpers/make-docker-config-retriever (a ImageReference)) credential-retriever (exactly 1)
+    (verifying [(credentials/retriever-chain (a ImageReference)) credential-retriever (exactly 1)
                 (pusher/authenticate (a RegistryClient)) any (exactly 1)]
                (is (instance? RegistryClient
                               (pusher/make-registry-client (ImageReference/parse "library/my-app:v1") {})))))
 
   (testing "when :anonymous? is set to true, neither attempts to retrieve
   credentials nor to authenticate on the registry"
-    (verifying [(jib.helpers/make-docker-config-retriever (a ImageReference)) any (exactly 0)
+    (verifying [(credentials/retriever-chain (a ImageReference)) any (exactly 0)
                 (pusher/authenticate (a RegistryClient)) any (exactly 0)]
                (is (instance? RegistryClient
                               (pusher/make-registry-client (ImageReference/parse "library/my-app:v1") {:anonymous? true}))))))
@@ -78,7 +78,7 @@
     (testing "ensures that all steps needed to push an image are being performed
   accordingly"
       (let [^DescriptorDigest image-digest (DescriptorDigest/fromDigest "sha256:ca3d163bab055381827226140568f3bef7eaac187cebd76878e0b63e9e442356")]
-        (providing [(jib.helpers/make-docker-config-retriever (a ImageReference)) credential-retriever
+        (providing [(credentials/retriever-chain (a ImageReference)) credential-retriever
                     (pusher/authenticate (a RegistryClient)) any
                     (#'pusher/check-blob (a RegistryClient) layer1-digest) true
                     (#'pusher/check-blob (a RegistryClient) layer2-digest) true
@@ -90,7 +90,7 @@
                                       :temp-dir temp-dir}))))))
 
     (testing "throws an exception when one of the layers can't be pushed"
-      (providing [(jib.helpers/make-docker-config-retriever (a ImageReference)) credential-retriever
+      (providing [(credentials/retriever-chain (a ImageReference)) credential-retriever
                   (pusher/authenticate (a RegistryClient)) any
                   (#'pusher/check-blob (a RegistryClient) layer1-digest) true
                   (#'pusher/check-blob (a RegistryClient) layer2-digest) (calling (fn [_ _]

--- a/test/vessel/jib/credentials_test.clj
+++ b/test/vessel/jib/credentials_test.clj
@@ -1,0 +1,78 @@
+(ns vessel.jib.credentials-test
+  (:require [clojure.test :refer :all]
+            [cognitect.aws.client.api :as aws]
+            [matcher-combinators.standalone :as standalone]
+            [mockfn.macros :refer [providing]]
+            [vessel.jib.credentials :as credentials])
+  (:import [com.google.cloud.tools.jib.api Credential CredentialRetriever ImageReference]
+           com.google.cloud.tools.jib.registry.credentials.CredentialRetrievalException
+           java.util.Optional))
+
+(deftest get-ecr-credential-test
+  (providing [(aws/client (standalone/match? {:api    :ecr
+                                              :region "us-east-1"})) 'client]
+
+             (testing "returns username and password to access the ECR registry that the
+  image in question is associated to"
+               (providing [(aws/invoke 'client {:op      :GetAuthorizationToken
+                                                :request {:registryIds ["591385309914"]}})
+                           {:authorizationData [{:authorizationToken "QVdTOnBhc3N3b3Jk"}]}]
+                          (is (= {:username "AWS"
+                                  :password "password"}
+                                 (credentials/get-ecr-credential
+                                  (ImageReference/parse "591385309914.dkr.ecr.us-east-1.amazonaws.com/application:v1.0.1"))))))
+
+             (testing "throws a CredentialRetrievalException when the
+             authentication on ECR fails"
+               (providing [(aws/invoke 'client {:op      :GetAuthorizationToken
+                                                :request {:registryIds ["591385309914"]}})
+                           {:cognitect.anomalies/category :cognitect.anomalies/incorrect}]
+                          (is (thrown? CredentialRetrievalException
+                                       (credentials/get-ecr-credential
+                                        (ImageReference/parse "591385309914.dkr.ecr.us-east-1.amazonaws.com/application:v1.0.1"))))))))
+
+(deftest ecr-credential-retriever-test
+  (testing "returns the credential to access Amazon ECR"
+    (let [image (ImageReference/parse "591385309914.dkr.ecr.us-east-1.amazonaws.com/application:v1.0.1")]
+      (providing [(credentials/get-ecr-credential image) {:username "AWS" :password "password"}]
+                 (let [retriever  (credentials/ecr-credential-retriever image)
+                       credential (.. retriever retrieve get)]
+                   (is (= "AWS"
+                          (.getUsername credential)))
+                   (is (= "password"
+                          (.getPassword credential)))))))
+
+  (testing "returns Optional/empty when the image isn't associated to an ECR registry"
+    (let [image (ImageReference/parse "docker.io/repo/application:v1.0.1")]
+      (let [retriever (credentials/ecr-credential-retriever image)]
+        (is (false? (.. retriever retrieve isPresent)))))))
+
+(defn make-retriever
+  ([]
+   (fn [_]
+     (reify CredentialRetriever
+       (retrieve [this]
+         (Optional/empty)))))
+  ([username password]
+   (fn [_]
+     (reify CredentialRetriever
+       (retrieve [this]
+         (Optional/of (Credential/from username password)))))))
+
+(deftest retriever-chain-test
+  (testing "returns the first non-empty credential retrieved by the supplied
+  retrievers"
+    (let [get-credentials (fn [credentials]
+                            [(.getUsername credentials) (.getPassword credentials)])]
+      (are [retrievers username password] (= [username password]
+                                             (get-credentials (.. (credentials/retriever-chain (ImageReference/parse "repo/application:v1.0.1") retrievers) retrieve get)))
+        [(make-retriever "john.doe" "abc123")]                                "john.doe" "abc123"
+        [(make-retriever "john.doe" "abc123") (make-retriever "jd" "def456")] "john.doe" "abc123"
+        [(make-retriever "jd" "def456") (make-retriever "john.doe" "abc123")] "jd"       "def456"
+        [(make-retriever) (make-retriever "john.doe" "abc123")]               "john.doe" "abc123"
+        [(make-retriever "john.doe" "abc123") (make-retriever)]               "john.doe" "abc123")))
+
+  (testing "returns Optional/empty when all retrievers return empty credentials"
+    (is (= (Optional/empty)
+           (.. (credentials/retriever-chain (ImageReference/parse "repo/application:v1.0.1") [(make-retriever) (make-retriever)])
+               retrieve)))))


### PR DESCRIPTION
As of this pull request, Vessel will have an internal chain of credential
retrievers. Currently, it supports two retrievers: Amazon Elastic Container
Registry (ECR) and Docker config. The former provides an out of the box
integration with ECR and it's particularly useful for CI pipelines where
credentials can be obtained through instance profiles without any additional
configuration. The later one relies on the plain Docker config credential
retriever supplied by Google Jib.