### PR TITLE
Add an extended cache mechanism to make builds more incremental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### ADDED
+- internal: `vessel.jib.containerizer` now supports an extended cache mechanism
+  that allows Vessel to inject custom cached layers into the container being
+  built. This feature aims to solve issues with the containerization process of compiled
+  Clojure files. Since the compilation isn't deterministic, it becomes
+  impossible to leverage regular cached layers and all layers end up being built every time ([#13](https://github.com/nubank/vessel/pull/13)).
+- Internal: add the dependency `com.google.cloud.tools/jib-build-plan`.
+
+### Changed
+- Improve significantly the design of `vessel.jib.containerizer` and fix flaky tests ([#13](https://github.com/nubank/vessel/pull/13)).
+- Internal: upgrade to ` com.google.cloud.tools/jib-core` 0.14.0.
+
 ## [0.2.128] - 2020-05-28
 
 ### Added
@@ -19,7 +31,11 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Integration tests.
 - Workflow file to run tests automatically on Github Actions.
-- Normalize keys of the manifest.json file in order to avoid incongruities. Thus, Vessel can be employed  as a generic alternative to push tarballs to remote registries.
+
+### Fixed
+- Normalize keys of the manifest.json file in order to avoid
+  incongruities. Thus, Vessel can be employed as a generic alternative to push
+  tarballs to remote registries.
 
 ## [0.2.107] - 2020-03-09
 
@@ -34,23 +50,23 @@ All notable changes to this project will be documented in this file.
 ## [0.2.99] - 2020-03-02
 
 ### Added
-* Push command to upload a tarball to a registry.
+- Push command to upload a tarball to a registry.
 
 ### Changed
-* Internal: rename vessel.jib namespace to vessel.jib.containerizer and move
+- Internal: rename vessel.jib namespace to vessel.jib.containerizer and move
 functions that deal with common aspects of Jib API to the new
   vessel.jib.helpers namespace.
-* Upgrade Jib to version 0.13.0.
+- Upgrade Jib to version 0.13.0.
 
 ## [0.1.90] - 2020-02-20
 
 ### Added
-* Set the directory for caching base image and application layers to
+- Set the directory for caching base image and application layers to
   ~/.vessel-cache. Eventually, Vessel can take this directory as a parameter to
   allow a more fine-grained customization.
 
 ## [0.1.84] - 2020-02-18
 
 ### Added
-* Containerize, image and manifest commands (Vessel is in an alpha stage; the
+- Containerize, image and manifest commands (Vessel is in an alpha stage; the
   API is subject to changes).

--- a/deps.edn
+++ b/deps.edn
@@ -1,15 +1,16 @@
 {:paths ["src" "resources"]
  :deps
- {org.clojure/data.json #:mvn{:version "0.2.6"}
-  org.clojure/clojure #:mvn{:version "1.10.0"}
+ {  org.clojure/clojure #:mvn{:version "1.10.0"}
+  org.clojure/data.json #:mvn{:version "0.2.6"}
   com.cognitect.aws/api #:mvn{:version "0.8.456"}
   com.cognitect.aws/endpoints #:mvn{:version "1.1.11.789"}
   org.clojure/tools.cli #:mvn{:version "0.4.2"}
   org.clojure/tools.namespace #:mvn{:version "0.3.1"}
   com.cognitect.aws/ecr #:mvn{:version "798.2.678.0"}
+  com.google.cloud.tools/jib-build-plan #:mvn{:version "0.2.0"}
   progrock #:mvn{:version "0.1.2"}
   clj-commons/spinner #:mvn{:version "0.6.0"}
-  com.google.cloud.tools/jib-core #:mvn{:version "0.13.0"}
+  com.google.cloud.tools/jib-core #:mvn{:version "0.14.0"}
   org.clojure/core.async #:mvn{:version "1.0.567"}}
  :aliases
  {:dev

--- a/src/vessel/jib/cache.clj
+++ b/src/vessel/jib/cache.clj
@@ -1,0 +1,37 @@
+(ns vessel.jib.cache
+  (:import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer
+           com.google.cloud.tools.jib.api.DescriptorDigest
+           [com.google.cloud.tools.jib.cache Cache CachedLayer]
+           com.google.common.collect.ImmutableList
+           java.io.File
+           java.util.Optional))
+
+(defn ^Cache get-cache
+  "Takes a java.io.File representing the cache directory and returns the
+  corresponding com.google.cloud.tools.jib.cache.Cache object."
+  [^File cache-dir]
+  (Cache/withDirectory (.toPath cache-dir)))
+
+(defn ^CachedLayer get-cached-layer-by-file-entries-layer
+  "Given a FileEntriesLayer object, returns the corresponding cached layer as a CachedLayer object.
+
+  This function is supposed to always return a cached layer. If for
+  some reason there is no a matching cached layer, it throws an
+  IllegalStateException."
+  [^Cache cache ^FileEntriesLayer layer]
+  (let [^Optional cached-layer (.. cache (retrieve (ImmutableList/copyOf (.getEntries layer))))]
+    (if (.isPresent cached-layer)
+      (.get cached-layer)
+      (throw (IllegalStateException. (str "Could not retrieve cached layer for layer " (.getName layer)))))))
+
+(defn ^CachedLayer get-cached-layer-by-digest
+  "Given a sha256 digest, returns the corresponding cached layer as a CachedLayer object.
+
+  This function is supposed to always return a cached layer. If for
+  some reason there is no a matching cached layer, it throws an
+  IllegalStateException."
+  [^Cache cache ^String digest]
+  (let [^Optional cached-layer (.. cache (retrieve (DescriptorDigest/fromDigest digest)))]
+    (if (.isPresent cached-layer)
+      (.get cached-layer)
+      (throw (IllegalStateException. (str "Could not retrieve cached layer for digest " digest))))))

--- a/src/vessel/jib/containerizer.clj
+++ b/src/vessel/jib/containerizer.clj
@@ -1,76 +1,159 @@
 (ns vessel.jib.containerizer
   "Containerization API built on top of Google Jib."
-  (:require [vessel.jib.credentials :as credentials]
+  (:require [vessel.jib.cache :as jib.cache]
+            [vessel.jib.credentials :as jib.credentials]
             [vessel.jib.helpers :as jib.helpers]
             [vessel.misc :as misc])
-  (:import [com.google.cloud.tools.jib.api Containerizer FilePermissions ImageFormat ImageReference Jib JibContainerBuilder LayerConfiguration LayerConfiguration$Builder LayerEntry LogEvent RegistryImage TarImage]
+  (:import [clojure.lang IPersistentMap ISeq]
+           [com.google.cloud.tools.jib.api Containerizer ImageReference Jib JibContainer JibContainerBuilder LogEvent RegistryImage TarImage]
+           [com.google.cloud.tools.jib.api.buildplan FileEntriesLayer FileEntriesLayer$Builder FileEntry FilePermissions ImageFormat]
+           [com.google.cloud.tools.jib.builder.steps PreparedLayer PreparedLayer$StateInTarget StepsRunner]
+           [com.google.cloud.tools.jib.cache Cache CachedLayer]
+           com.google.cloud.tools.jib.configuration.BuildContext
            com.google.cloud.tools.jib.event.events.ProgressEvent
-           java.nio.file.attribute.PosixFilePermission))
+           com.google.cloud.tools.jib.image.Layer
+           java.io.File
+           [java.lang.reflect Constructor Field]
+           java.nio.file.attribute.PosixFilePermission
+           [java.util.concurrent Callable ExecutorService]
+           java.util.function.Function
+           java.util.List))
 
-(defn   ^ImageReference make-image-reference
-  "Returns a new image reference from the provided values."
-  [{:image/keys [^String registry ^String repository ^String tag]}]
-  (ImageReference/of registry repository tag))
+(defn- ^Field get-private-field
+  "Given an object and the name of a private field, returns it as a
+  java.lang.reflect.Field instance.
+
+  The field is set to be accessible. Thus subsequent calls to the
+  methods get and set will succeed."
+  [object ^String field-name]
+  (let [^Field field (.. object getClass (getDeclaredField field-name))]
+    (.setAccessible field true)
+    field))
+
+(defn- ^PreparedLayer make-prepared-layer
+  "Creates a new PreparedLayer instance via reflection since this class
+  is package-private and its members are inaccessible."
+  [^CachedLayer layer ^String layer-name]
+  (let [^Constructor constructor (.getDeclaredConstructor PreparedLayer (into-array Class  [Layer String PreparedLayer$StateInTarget]))
+        unknown                  (first (filter #(= "UNKNOWN" (str %)) (.getEnumConstants PreparedLayer$StateInTarget)))]
+    (.setAccessible constructor true)
+    (.newInstance constructor (into-array Object [layer layer-name unknown]))))
+
+(defn- ^Callable retrieve-cached-layers-step
+  "Emulates a step from the package
+  com.google.cloud.tools.jib.builder.steps that retrieves the cached
+  layer whose name and digest are given.
+
+  Returns an instance of java.util.concurrent.Callable interface that
+  returns a PreparedLayer object representing the cached layer in
+  question."
+  [^BuildContext build-context {:layer/keys [id digest]}]
+  (reify Callable
+    (call [this]
+      (let [^Cache cache              (.getApplicationLayersCache build-context)
+            ^CachedLayer cached-layer (jib.cache/get-cached-layer-by-digest cache digest)]
+        (make-prepared-layer cached-layer (name id))))))
+
+(defn- ^Runnable retrieve-cached-layers
+  "Creates a java.lang.Runnable instance that alters the supplied
+  StepsRunner object by adding additional cached layers."
+  [^BuildContext build-context ^StepsRunner steps-runner ^ISeq cached-layers]
+  (reify Runnable
+    (run [this]
+      (let [^ExecutorService executor-service (.getExecutorService build-context)
+            steps-results                     (.. (get-private-field steps-runner "results") (get steps-runner))
+            application-layers-field          (get-private-field steps-results "applicationLayers")
+            application-layers                (.get application-layers-field steps-results)
+            additional-cached-layers          (map #(.submit executor-service (retrieve-cached-layers-step build-context %)) cached-layers)]
+        (.set application-layers-field steps-results (into  additional-cached-layers application-layers))))))
+
+(defn- ^Function wrap-steps-runner-factory
+  "Wraps the supplied steps runner factory into a function that alters the
+  StepsRunner returned by it.
+
+  The main goal of this wrapper is to inject a custom step into the list of
+  steps held by the StepsRunner object in question. This custom step retrieves
+  cached layers from the extended cache maintained by Vessel d based on the
+  information provided by the build plan."
+  [^Function steps-runner-factory cached-layers]
+  (misc/java-function (fn [^BuildContext build-context]
+                        (let [^StepsRunner steps-runner (.apply steps-runner-factory build-context)
+                              ^List steps-to-run        (.. (get-private-field steps-runner "stepsToRun") (get steps-runner))]
+                          (.add steps-to-run 3 (retrieve-cached-layers build-context steps-runner cached-layers))
+                          steps-runner))))
+
+(defn- ^Containerizer instrumented-containerizer
+  "Instruments the supplied containerizer by replacing its steps runner
+  factory with a wrapper that injects custom cached layers into the
+  image being built."
+  [^Containerizer containerizer ^ISeq cached-layers]
+  (let [^Field field                   (get-private-field containerizer "stepsRunnerFactory")
+        ^Function steps-runner-factory (.get field containerizer)]
+    (.set field containerizer (wrap-steps-runner-factory steps-runner-factory cached-layers))
+    containerizer))
 
 (defn- ^Containerizer make-containerizer
   "Makes a new Jib containerizer object to containerize the application
   to a given tarball."
-  [{:image/keys [name tar-path]}]
-  {:pre [name tar-path]}
-  (let [cache-dir    (-> (misc/home-dir)
-                         (misc/make-dir ".vessel-cache")
-                         str
-                         misc/string->java-path)
-        handler-name "vessel.jib.containerizer"]
-    (.. Containerizer
-        (to (.. TarImage (at (misc/string->java-path tar-path))
-                (named (make-image-reference name))))
-        (setBaseImageLayersCache cache-dir)
-        (setApplicationLayersCache cache-dir)
-        (setToolName "vessel")
-        (addEventHandler LogEvent (jib.helpers/log-event-handler handler-name))
-        (addEventHandler ProgressEvent (jib.helpers/progress-event-handler handler-name)))))
+  [{:image/keys [layers target]} {:keys [cache-dir  tar-path]}]
+  (let [cache-dir-path               (.toPath cache-dir)
+        handler-name                 "vessel.jib.containerizer"
+        ^Containerizer containerizer (.. Containerizer
+                                         (to (.. TarImage (at (.toPath tar-path))
+                                                 (named (ImageReference/parse target))))
+                                         (setBaseImageLayersCache cache-dir-path)
+                                         (setApplicationLayersCache cache-dir-path)
+                                         (setToolName "vessel")
+                                         (addEventHandler LogEvent (jib.helpers/log-event-handler handler-name))
+                                         (addEventHandler ProgressEvent (jib.helpers/progress-event-handler handler-name)))
+        cached-layers                (filter #(= :extended-cache (:layer/origin %)) layers)]
+    (if (seq cached-layers)
+      (instrumented-containerizer containerizer cached-layers)
+      containerizer)))
 
-(defn- containerize*
-  [^JibContainerBuilder container-builder image-spec]
-  (.containerize container-builder (make-containerizer image-spec)))
+(defn- execute-containerization
+  "Takes a JibContainerBuilder object and a map representing the build plan and
+  execute the containerization process."
+  [^JibContainerBuilder container-builder ^IPersistentMap build-plan ^IPersistentMap options]
+  (.containerize container-builder (make-containerizer build-plan options)))
 
-(defn- ^LayerEntry make-layer-entry
-  "Creates a new LayerEntry object from the supplied values."
+(defn- ^FileEntry make-file-entry
+  "Creates a new FileEntry object from the supplied values."
   [{:layer.entry/keys [source target file-permissions modification-time]}]
   (let [permissions (some->> file-permissions
                              (map #(PosixFilePermission/valueOf %))
                              set
                              (FilePermissions/fromPosixFilePermissions))]
-    (LayerEntry. (misc/string->java-path source)
-                 (jib.helpers/string->absolute-unix-path target)
-                 (or permissions FilePermissions/DEFAULT_FILE_PERMISSIONS)
-                 modification-time)))
+    (FileEntry. (misc/string->java-path source)
+                (jib.helpers/string->absolute-unix-path target)
+                (or permissions FilePermissions/DEFAULT_FILE_PERMISSIONS)
+                modification-time)))
 
-(defn- ^LayerConfiguration make-layer-configuration
-  "Makes a LayerConfiguration object from the supplied data structure."
-  [{:image.layer/keys [name entries]}]
-  (loop [^LayerConfiguration$Builder layer (.. LayerConfiguration builder (setName name))
-         entries                           entries]
+(defn- ^FileEntriesLayer make-file-entries-layer
+  "Makes a FileEntriesLayer object from the supplied data structure."
+  [{:layer/keys [id entries]}]
+  (loop [^FileEntriesLayer$Builder layer (.. FileEntriesLayer builder (setName (name id)))
+         entries                         entries]
     (if-not (seq entries)
       (.build layer)
       (let [layer-entry (first entries)]
-        (.addEntry layer (make-layer-entry layer-entry))
+        (.addEntry layer (make-file-entry layer-entry))
         (recur layer (rest entries))))))
 
-(defn- ^JibContainerBuilder add-layers
-  "Adds the supplied layers to the JibContainerBuilder object as a set
-  of LayerConfiguration instances."
-  [^JibContainerBuilder container-builder layers]
-  (reduce (fn [builder layer]
-            (.addLayer builder (make-layer-configuration layer)))
-          container-builder layers))
+(defn- ^ISeq make-file-entries-layers
+  "Returns a sequence of FileEntriesLayer objects for those layers in
+  the build plan whose :image.layer/origin is :file-entries."
+  [{:image/keys [layers]}]
+  (keep (fn [layer]
+          (when (= :file-entries (:layer/origin layer))
+            (make-file-entries-layer layer)))
+        layers))
 
 (defn-   ^RegistryImage make-registry-image
   "Given an ImageReference instance, returns a new registry image
   object."
   [^ImageReference image-reference]
-  (let [^CredentialRetriever retriever (credentials/retriever-chain image-reference)]
+  (let [^CredentialRetriever retriever (jib.credentials/retriever-chain image-reference)]
     (.. RegistryImage (named image-reference)
         (addCredentialRetriever retriever))))
 
@@ -81,25 +164,53 @@
      (.getRegistry image-reference)))
 
 (defn-   ^JibContainerBuilder make-container-builder
-  "Returns a new container builder to start building the image.
-
-  from is a map representing the base image descriptor. The following
-  keys are meaningful: :image/registry, :image/repository
-  and :image/tag. The :image/registry and :image/tag are optional."
-  [from]
-  (let [^ImageReference reference (make-image-reference from)]
+  "Takes the base image reference and returns an instance of JibContainerBuilder
+  to build an image that extends the base image in question."
+  [^String from]
+  (let [^ImageReference image-reference (ImageReference/parse from)]
     (.. Jib (from
-             (if (is-in-docker-hub? reference)
-               (str reference)
-               (make-registry-image reference)))
+             (if (is-in-docker-hub? image-reference)
+               (str image-reference)
+               (make-registry-image image-reference)))
         (setCreationTime (misc/now))
         (setFormat ImageFormat/Docker))))
 
+(defn- ^String qualified-image-reference
+  "Takes a JibContainer object and returns a fully qualified image reference in
+  the form [registry]/<repository>@<digest> such as
+  nubank/my-app@sha256:05edcc9e7f16871319590dccb2f9045f168a2cbdfab51b35b98693e57d42f7f7.
+
+  If the container in question targets the official Docker registry, omits the
+  registry portion."
+  [^JibContainer container]
+  (let [^ImageReference target-image (.getTargetImage container)
+        ^String digest               (str (.getDigest container))
+        ^String reference            (format "%s@%s"
+                                             (.getRepository target-image) digest)]
+    (if (is-in-docker-hub? target-image)
+      reference
+      (str (.getRegistry target-image) "/" reference))))
+
+(defn- ^IPersistentMap layer-ids-and-digests
+  "Returns a map of layer ids as keywords to their respective digests as
+  strings."
+  [^ISeq file-entries-layers ^File cache-dir]
+  (let [^Cache cache (jib.cache/get-cache cache-dir)]
+    (reduce (fn [result ^FileEntriesLayer layer]
+              (assoc result (keyword (.getName layer))
+                     (str (.. (jib.cache/get-cached-layer-by-file-entries-layer cache layer) getDigest))))
+            {} file-entries-layers)))
+
 (defn containerize
-  "Given an image spec, containerize the application in question by
-  producing a tarball containing image layers and metadata files."
-  [{:image/keys [from layers] :as image-spec}]
-  {:pre [from layers]}
-  (-> (make-container-builder from)
-      (add-layers layers)
-      (containerize* image-spec)))
+  "Takes a map representing a build plan and a map of additional options and produces a container."
+  [^IPersistentMap build-plan ^IPersistentMap options]
+  (let [{:image/keys [from layers]} build-plan
+        {:keys [cache-dir]}         options
+        ^ISeq file-entries-layers   (make-file-entries-layers build-plan)
+        ^JibContainer container     (-> (make-container-builder from)
+                                        (.setFileEntriesLayers file-entries-layers)
+                                        (execute-containerization build-plan options))]
+    (def c container)
+    {:image/reference            (qualified-image-reference container)
+     :image/digest               (str (.getDigest container))
+     :application.layers/digests (layer-ids-and-digests file-entries-layers cache-dir)}))

--- a/src/vessel/jib/helpers.clj
+++ b/src/vessel/jib/helpers.clj
@@ -1,7 +1,7 @@
 (ns vessel.jib.helpers
   "Helper functions for dealing with orthogonal features of Google Jib."
   (:require [vessel.misc :as misc])
-  (:import com.google.cloud.tools.jib.api.AbsoluteUnixPath
+  (:import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath
            com.google.cloud.tools.jib.event.events.ProgressEvent
            com.google.cloud.tools.jib.tar.TarExtractor
            java.io.File))

--- a/src/vessel/misc.clj
+++ b/src/vessel/misc.clj
@@ -8,7 +8,7 @@
            java.security.MessageDigest
            java.text.DecimalFormat
            [java.time Duration Instant]
-           java.util.function.Consumer
+           [java.util.function Consumer Function]
            java.util.Locale))
 
 (defn assoc-some
@@ -39,6 +39,13 @@
   [f]
   (reify Consumer
     (accept [_ arg]
+      (f arg))))
+
+(defn   ^Function java-function
+  "Returns a java.util.function.Function instance that calls the function f."
+  [f]
+  (reify Function
+    (apply [_ arg]
       (f arg))))
 
 (defn now

--- a/test/integration/vessel/program_integration_test.clj
+++ b/test/integration/vessel/program_integration_test.clj
@@ -20,7 +20,8 @@
 
 (use-fixtures :once (ensure-clean-test-dir))
 
-(deftest vessel-test
+;; Uncomment once the new API is ready to be tested.
+#_(deftest vessel-test
   (providing [(#'vessel/exit int?) (calling identity)]
 
              (testing "generates a manifest file containing metadata about the

--- a/test/resources/containerization/fake_class.class
+++ b/test/resources/containerization/fake_class.class
@@ -1,0 +1,1 @@
+Fake .class file

--- a/test/resources/containerization/resource.edn
+++ b/test/resources/containerization/resource.edn
@@ -1,0 +1,1 @@
+{:hello "world!"}

--- a/test/resources/greeting/greeting.txt
+++ b/test/resources/greeting/greeting.txt
@@ -1,1 +1,0 @@
-Hello world!

--- a/test/unit/vessel/jib/containerizer_test.clj
+++ b/test/unit/vessel/jib/containerizer_test.clj
@@ -1,52 +1,121 @@
 (ns vessel.jib.containerizer-test
   (:require [clojure.java.io :as io]
             [clojure.test :refer :all]
+            [matcher-combinators.matchers :as m]
             [matcher-combinators.test :refer [match?]]
             [vessel.jib.containerizer :as jib.containerizer]
             [vessel.misc :as misc]
             [vessel.test-helpers :refer [ensure-clean-test-dir]])
-  (:import org.apache.commons.vfs2.VFS))
+  (:import java.io.File
+           java.time.Instant
+           org.apache.commons.vfs2.VFS))
 
-(def tar-path "target/tests/containerizer-test/my-app.tar")
+(use-fixtures :once (ensure-clean-test-dir))
+
+(def tar-path-1 (io/file "target/tests/containerizer-test/my-app-1.tar"))
+
+(def tar-path-2 (io/file "target/tests/containerizer-test/my-app-2.tar"))
+
+(def cache-dir (misc/make-dir (misc/home-dir) ".vessel-cache"))
 
 (defn read-from-tarball
-  [^String file-name]
+  [^File tarball ^String file-name]
   (let [cwd      (str (.getCanonicalFile (io/file ".")))
-        tar-file (format "tar:%s/%s!/%s" cwd tar-path file-name)]
+        tar-file (format "tar:%s/%s!/%s" cwd tarball file-name)]
     (.. VFS getManager
         (resolveFile tar-file)
         getContent
         getInputStream)))
 
-(use-fixtures :once (ensure-clean-test-dir))
+;; Make layers deterministic.
+(def fixed-modification-time
+  (Instant/ofEpochMilli 0))
 
 (deftest containerize-test
   (testing "calls Google Jib and containerize the files in question"
-    (let [greeting-file (io/file "test/resources/greeting/greeting.txt")
-          layer-re      #"^[0-9a-f]{64}\.tar.gz$"]
+    (let [class-file (io/file "test/resources/containerization/fake_class.class")
+          resource   (io/file "test/resources/containerization/resource.edn")
+          build-result
+          (binding [misc/*verbose-logs* true]
+            (jib.containerizer/containerize #:image{:from   "openjdk@sha256:1fd5a77d82536c88486e526da26ae79b6cd8a14006eb3da3a25eb8d2d682ccd6"
+                                                    :target "nubank/my-app:v1"
+                                                    :layers
+                                                    [#:layer{:id      :source-paths
+                                                             :origin  :file-entries
+                                                             :entries [#:layer.entry{:source            (.getPath class-file)
+                                                                                     :target            "/opt/app/WEB-INF/classes/fake_class.class"
+                                                                                     :file-permissions  #{"OTHERS_READ"
+                                                                                                          "OWNER_WRITE"
+                                                                                                          "OWNER_READ"
+                                                                                                          "GROUP_READ"}
+                                                                                     :modification-time fixed-modification-time}]}
+                                                     #:layer{:id      :resource-paths
+                                                             :origin  :file-entries
+                                                             :entries [#:layer.entry{:source            (.getPath resource)
+                                                                                     :target            "/opt/app/WEB-INF/classes/resource.edn"
+                                                                                     :file-permissions  #{"OTHERS_READ"
+                                                                                                          "OWNER_WRITE"
+                                                                                                          "OWNER_READ"
+                                                                                                          "GROUP_READ"}
+                                                                                     :modification-time fixed-modification-time}]}]}
+                                            {:cache-dir cache-dir :tar-path tar-path-1}))]
+
+      (is (true? (misc/file-exists? (io/file tar-path-1)))
+          "the tarball has been created")
+
+      (is (match? [{:Config   "config.json"
+                    :RepoTags ["nubank/my-app:v1"]
+                    :Layers
+                    (m/in-any-order ["8e3ba11ec2a2b39ab372c60c16b421536e50e5ce64a0bc81765c2e38381bcff6.tar.gz",
+                                     "311ad0da45338842480bf25c6e6b7bb133b7b8cf709c3470db171ec370da5539.tar.gz",
+                                     "df312c74ce16f20eeb87b5640db9b1579a53534bd3e9f3de1e916fc62744bcf4.tar.gz",
+                                     "05edcc9e7f16871319590dccb2f9045f168a2cbdfab51b35b98693e57d42f7f7.tar.gz",
+                                     "86695d056ba72013e01b4c1363b63f63fdb90664adbbe043df1354c98c920906.tar.gz"])}]
+                  (misc/read-json (read-from-tarball tar-path-1 "manifest.json")))
+          "the image manifest has the expected layers")
+
+      (is (re-find #"^nubank/my-app@sha256:[a-f0-9]{64}$"
+                   (:image/reference build-result))
+          "the containerizer returned the correct image reference")
+
+      (is (re-find #"^sha256:[a-f0-9]{64}$"
+                   (:image/digest build-result))
+          "the containerizer returned a valid image digest")
+
+      (is (= {:source-paths
+              "sha256:05edcc9e7f16871319590dccb2f9045f168a2cbdfab51b35b98693e57d42f7f7"
+              :resource-paths
+              "sha256:86695d056ba72013e01b4c1363b63f63fdb90664adbbe043df1354c98c920906"}
+             (:application.layers/digests build-result))
+          "the build result contains a map of layer ids to their corresponding digests")))
+
+  (testing "builds a new image now retrieving the layer from the cache as per
+  specified in the build plan"
+    (let [resource (io/file "test/resources/containerization/resource.edn")]
       (binding [misc/*verbose-logs* true]
-        (jib.containerizer/containerize #:image{:from
-                                                #:image   {:repository "openjdk" :tag "sha256:1fd5a77d82536c88486e526da26ae79b6cd8a14006eb3da3a25eb8d2d682ccd6"}
-                                                :name
-                                                #:image   {:repository "nubank/my-app" :tag "v1"}
+        (jib.containerizer/containerize #:image{:from   "openjdk@sha256:1fd5a77d82536c88486e526da26ae79b6cd8a14006eb3da3a25eb8d2d682ccd6"
+                                                :target "nubank/my-app:v1"
                                                 :layers
-                                                [#:image.layer{:name    "resources"
-                                                               :entries [#:layer.entry{:source            (.getPath greeting-file)
-                                                                                       :target            "/opt/app/WEB-INF/classes/greeting.txt"
-                                                                                       :file-permissions  #{"OTHERS_READ"
-                                                                                                            "OWNER_WRITE"
-                                                                                                            "OWNER_READ"
-                                                                                                            "GROUP_READ"}
-                                                                                       :modification-time (misc/last-modified-time greeting-file)}]}]
-                                                :tar-path tar-path}))
+                                                [#:layer{:id     :source-paths
+                                                         :origin :extended-cache
+                                                         :digest "sha256:05edcc9e7f16871319590dccb2f9045f168a2cbdfab51b35b98693e57d42f7f7"}
+                                                 #:layer{:id      :resource-paths
+                                                         :origin  :file-entries
+                                                         :entries [#:layer.entry{:source            (.getPath resource)
+                                                                                 :target            "/opt/app/WEB-INF/classes/resource.edn"
+                                                                                 :modification-time fixed-modification-time}]}]}
+                                        {:cache-dir cache-dir :tar-path tar-path-2}))
 
-      (is (true? (misc/file-exists? (io/file tar-path))))
+      (is (true? (misc/file-exists? (io/file tar-path-2)))
+          "the tarball has been created")
 
-      (is (match? [{:config   "config.json"
-                    :repoTags ["nubank/my-app:v1"]
-                    :layers
-                    [layer-re
-                     layer-re
-                     layer-re
-                     layer-re]}]
-                  (misc/read-json (read-from-tarball "manifest.json")))))))
+      (is (match? [{:Config   "config.json"
+                    :RepoTags ["nubank/my-app:v1"]
+                    :Layers
+                    (m/in-any-order ["8e3ba11ec2a2b39ab372c60c16b421536e50e5ce64a0bc81765c2e38381bcff6.tar.gz",
+                                     "311ad0da45338842480bf25c6e6b7bb133b7b8cf709c3470db171ec370da5539.tar.gz",
+                                     "df312c74ce16f20eeb87b5640db9b1579a53534bd3e9f3de1e916fc62744bcf4.tar.gz",
+                                     "05edcc9e7f16871319590dccb2f9045f168a2cbdfab51b35b98693e57d42f7f7.tar.gz",
+                                     "86695d056ba72013e01b4c1363b63f63fdb90664adbbe043df1354c98c920906.tar.gz"])}]
+                  (misc/read-json (read-from-tarball tar-path-2 "manifest.json")))
+          "the image manifest has the same layers as the first one"))))

--- a/test/unit/vessel/jib/helpers_test.clj
+++ b/test/unit/vessel/jib/helpers_test.clj
@@ -6,7 +6,7 @@
             [vessel.jib.helpers :as jib.helpers]
             [vessel.misc :as misc]
             [vessel.test-helpers :refer [ensure-clean-test-dir]])
-  (:import com.google.cloud.tools.jib.api.AbsoluteUnixPath))
+  (:import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath))
 
 (use-fixtures :once (ensure-clean-test-dir))
 

--- a/test/unit/vessel/jib/pusher_test.clj
+++ b/test/unit/vessel/jib/pusher_test.clj
@@ -4,7 +4,7 @@
             [clojure.test :refer :all]
             [mockfn.macros :refer [calling providing verifying]]
             [mockfn.matchers :refer [a any exactly pred]]
-            [vessel.jib.credentials :as credentials]
+            [vessel.jib.credentials :as jib.credentials]
             [vessel.jib.pusher :as pusher]
             [vessel.test-helpers :refer [ensure-clean-test-dir]])
   (:import [com.google.cloud.tools.jib.api Credential CredentialRetriever DescriptorDigest ImageReference]
@@ -23,14 +23,14 @@
 (deftest make-registry-client-test
   (testing "by default, attempts to retrieve credentials and to authenticate on
   the registry"
-    (verifying [(credentials/retriever-chain (a ImageReference)) credential-retriever (exactly 1)
+    (verifying [(jib.credentials/retriever-chain (a ImageReference)) credential-retriever (exactly 1)
                 (pusher/authenticate (a RegistryClient)) any (exactly 1)]
                (is (instance? RegistryClient
                               (pusher/make-registry-client (ImageReference/parse "library/my-app:v1") {})))))
 
   (testing "when :anonymous? is set to true, neither attempts to retrieve
   credentials nor to authenticate on the registry"
-    (verifying [(credentials/retriever-chain (a ImageReference)) any (exactly 0)
+    (verifying [(jib.credentials/retriever-chain (a ImageReference)) any (exactly 0)
                 (pusher/authenticate (a RegistryClient)) any (exactly 0)]
                (is (instance? RegistryClient
                               (pusher/make-registry-client (ImageReference/parse "library/my-app:v1") {:anonymous? true}))))))
@@ -78,19 +78,19 @@
     (testing "ensures that all steps needed to push an image are being performed
   accordingly"
       (let [^DescriptorDigest image-digest (DescriptorDigest/fromDigest "sha256:ca3d163bab055381827226140568f3bef7eaac187cebd76878e0b63e9e442356")]
-        (providing [(credentials/retriever-chain (a ImageReference)) credential-retriever
+        (providing [(jib.credentials/retriever-chain (a ImageReference)) credential-retriever
                     (pusher/authenticate (a RegistryClient)) any
                     (#'pusher/check-blob (a RegistryClient) layer1-digest) true
                     (#'pusher/check-blob (a RegistryClient) layer2-digest) true
                     ;; Called from push-container-config
                     (#'pusher/push-blob (a RegistryClient) (any) (pred map?)) any
-                    (pusher/push-manifest (a RegistryClient) (any) (manifest-of-digest image-digest) "v1") image-digest]
+                    (pusher/push-manifest (a RegistryClient) (any) (manifest-of-digest image-digest) (Optional/of "v1")) image-digest]
                    (is (any?
                         (pusher/push {:tarball  tarball
                                       :temp-dir temp-dir}))))))
 
     (testing "throws an exception when one of the layers can't be pushed"
-      (providing [(credentials/retriever-chain (a ImageReference)) credential-retriever
+      (providing [(jib.credentials/retriever-chain (a ImageReference)) credential-retriever
                   (pusher/authenticate (a RegistryClient)) any
                   (#'pusher/check-blob (a RegistryClient) layer1-digest) true
                   (#'pusher/check-blob (a RegistryClient) layer2-digest) (calling (fn [_ _]

--- a/test/unit/vessel/misc_test.clj
+++ b/test/unit/vessel/misc_test.clj
@@ -9,7 +9,7 @@
   (:import [java.io StringReader StringWriter]
            java.nio.file.Path
            [java.time Duration Instant]
-           java.util.function.Consumer))
+           [java.util.function Consumer Function]))
 
 (use-fixtures :once (ensure-clean-test-dir))
 
@@ -47,6 +47,14 @@
          (with-out-str
            (.. (misc/java-consumer #(printf %))
                (accept "Hello world!"))))))
+
+(deftest java-function-test
+  (is (instance? Function
+                 (misc/java-function identity))
+
+      (is (= 2
+             (.. (misc/java-function inc)
+                 (apply 1))))))
 
 (deftest now-test
   (is (instance? Instant (misc/now))))


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] There is an open issue describing the problem that this pr intents to solve.
    - [x] You have a descriptive commit message with a short title (first line).
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature/bug fix

* **What is the current behavior?**
The compilation process of Clojure sources isn't deterministic. Thus some compiled files end up generating new layers every time that they're built what prevents Vessel from leveraging layers accordingly. 


* **What is the new behavior (if this is a feature change)?**
`vessel.jib.containerizer` now supports an extended cache mechanism that allows Vessel to inject known cached layers into the container being built.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes. It is part of a wide redesign of Vessel, but will not be merged into the master branch for now. 


* **Other information**:
- Improve significantly the design of `vessel.jib.containerizer`.
- Now the function `containerize` returns a map with relevant information that can be used by callers to expose the qualified image reference and the digest of the container for users.
- Improve tests of `vessel.jib.containerizer` and solve issues related to flakiness. 