### PR TITLE
Add support for OSX in release command

### DIFF
--- a/build/release.sh
+++ b/build/release.sh
@@ -18,9 +18,17 @@ vessel_dir=$dist/vessel
 
 vessel_tar_gz=$dist/vessel-$version.tar.gz
 
+function get_today() {
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        gdate --utc +'%Y-%m-%d'
+    else
+        date --utc +'%Y-%m-%d'
+    fi
+}
+
 function update_changelog() {
     local changelog=$cur_dir/../CHANGELOG.md
-    local today=$(date --utc +'%Y-%m-%d')
+    local today=$(get_today)
     sed -ie "s/\(##\s*\[Unreleased\]\)/\1\n\n## [$version] - $today/g" $changelog
     git add $changelog; git commit -m "Release version $version."
     git push origin master


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

* **Please check if the PR fulfills these requirements**
- [ ] There is an open issue describing the problem that this pr intents to solve.
- [x] You have a descriptive commit message with a short title (first line).
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the current behavior?**
date command is only compatible with linux


* **What is the new behavior (if this is a feature change)?**
uses gdate in OSX 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
