### PR TITLE
Reader for Vessel manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to this project will be documented in this file.
   Clojure files. Since the compilation isn't deterministic, it becomes
   impossible to leverage regular cached layers and all layers end up being built every time ([#13](https://github.com/nubank/vessel/pull/13)).
 - Internal: add the dependency `com.google.cloud.tools/jib-build-plan`.
+- [#19](https://github.com/nubank/vessel/pull/19): introduce Vessel
+  manifests. Manifests are declarative files in the EDN format containing
+  various attributes that control how Vessel builds and containerizes Clojure
+  applications.
 
 ### Changed
 - Improve significantly the design of `vessel.jib.containerizer` and fix flaky tests ([#13](https://github.com/nubank/vessel/pull/13)).

--- a/src/vessel/misc.clj
+++ b/src/vessel/misc.clj
@@ -119,10 +119,32 @@
           ~level ~(str (ns-name *ns*)) ~message
           [~@args]))
 
+;; File system utilities.
+
 (defn file-exists?
   "Returns true if the file exists or false otherwise."
   [^File file]
   (.exists file))
+
+(defn file?
+  "True if f is a file."
+  [^File f]
+  (.isFile f))
+
+(defn directory?
+  "True if f is a directory."
+  [^File f]
+  (.isDirectory f))
+
+(defn absolute-file?
+  "True if the file or directory in question represents an absolute path."
+  [^File f]
+  (.isAbsolute f))
+
+(defn ^File canonicalize-file
+  "Returns the canonical version of the file f."
+  [^File f]
+  (.getCanonicalFile f))
 
 (defn filter-files
   "Given a sequence of java.io.File objects (either files or

--- a/src/vessel/reader.clj
+++ b/src/vessel/reader.clj
@@ -1,0 +1,164 @@
+(ns vessel.reader
+  "Reader for Vessel manifests."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.spec.alpha :as s]
+            [clojure.string :as string]
+            [clojure.walk :as walk]
+            [vessel.misc :as misc]
+            [vessel.v1 :as v1])
+  (:import [clojure.lang IPersistentMap IPersistentVector Keyword Symbol]
+           java.io.File
+           java.util.regex.Pattern))
+
+(defn- validate-with-spec
+  "Validates the manifest's structure using the spec :vessel.v1/manifest.
+
+  Returns the manifest untouched if it matches the spec or throws an exception
+  containing the problems otherwise."
+  [^IPersistentMap manifest]
+  (if-let [problems (s/explain-data ::v1/manifest manifest)]
+    (throw (ex-info "Invalid manifest. See further details about the violations below:" problems))
+    manifest))
+
+(defn- ^String expand-variable
+  "Takes a string s and a map of variables passed to Vessel at
+  build-time. Expands variables in the form {{var-name}} by replacing them with
+  matching values taken from the build-time variables map.
+
+  Variables have two forms:
+
+  {{var-name}}
+  {{var-name|default-value}}
+
+  In the second form, if the build-time-variables map doesn't contain a key
+  :var-name, the string \"default-value\" will be used. If a matching value
+  can't be found for a given variable name and there is no a default value for
+  it, throws an exception with a descriptive error message."
+  [^String s ^IPersistentMap build-time-variables]
+  (letfn [(explain-mismatch [^String variable ^Keyword k]
+            (format "No matching value found for variable \"%s\" at the build-time variables.
+Did you forget to pass --build-arg %s=<value> to Vessel?"
+                    variable (name k)))]
+    (string/replace s #"\{\{([^\}]+)\}\}" (fn [match]
+                                            (let [^String variable (string/trim (last match))
+                                                  [k d]            (string/split variable #"\|")
+                                                  ^Keyword key     (keyword (edn/read-string k))
+                                                  default-value    (when d
+                                                                     (string/trim d))]
+                                              (str (or (get build-time-variables key default-value)
+                                                       (throw (ex-info (explain-mismatch variable key)
+                                                                       {:variable             variable
+                                                                        :build-time-variables build-time-variables})))))))))
+
+(def non-expandable-keys
+  "Those keys don't accept variables because if they did, builds wouldn't be
+  deterministic and the Vessel's extended cache wouldn't work properly."
+  [::v1/app-root ::v1/classifiers  ::v1/resource-paths ::v1/source-paths])
+
+(defn- expand-all-variables
+  "Traverses the manifest map by expanding variables with matching arguments
+  passed to Vessel at build-time."
+  [^IPersistentMap manifest ^IPersistentMap build-time-variables]
+  (let [reduced-manifest (apply dissoc manifest non-expandable-keys)]
+    (merge manifest
+           (walk/postwalk #(if (string? %)
+                             (expand-variable % build-time-variables)
+                             %)
+                          reduced-manifest))))
+
+(defn- ^String derive-app-root
+  "Derives the app-root from the main-ns."
+  [^Symbol main-ns]
+  (let [split-at-dots #(string/split % #"\.")]
+    (->> main-ns
+         str
+         split-at-dots
+         (drop-last 1)
+         (string/join "/")
+         (str "/"))))
+
+(defn- merge-defaults
+  "Merge default values into the supplied manifest map."
+  [^IPersistentMap manifest]
+  (let [{::v1/keys [main-ns]} manifest
+        app-root              (derive-app-root main-ns)
+        defaults              #::v1 {:app-root       app-root
+                                     :app-type       :jar
+                                     :resource-paths #{}}]
+    (merge defaults manifest)))
+
+(defn- ^File ensure-file
+  "Turns the string x into a java.io.File object that satisfies the supplied
+  options.
+
+  Options is a map that control which validations should be performed and how
+  the conversion to a java.io.File occurs. The following boolean options are
+  valid: :absolute - checks if the file or directory in question is an absolute
+  path.
+
+  :canonicalize - returns a canonical file object.
+
+  :directory - checks if the file in question is a directory.
+
+  :exists - checks if the file or directory exists.
+
+  Throws an exception with a meaningful message if one of the aforementioned
+  validations fails."
+  [{:keys [absolute, canonicalize, directory, exists]} path ^String x]
+  (let [file (io/file x)
+        s    (print-str path)
+        data {:path path :value x}]
+    (when (and exists (not (misc/file-exists? file)))
+      (throw (ex-info (format "Invalid path at %s - no such file or directory: \"%s\"." s x)
+                      data)))
+    (when (and absolute (not (misc/absolute-file? file)))
+      (throw (ex-info (format "Invalid path at %s - \"%s\" isn't an absolute path." s x)
+                      data)))
+    (when (and directory (not (misc/directory? file)))
+      (throw (ex-info (format "Invalid path at %s - \"%s\" isn't a directory." s x)
+                      data)))
+    (if canonicalize
+      (misc/canonicalize-file file)
+      file)))
+
+(defn- ^Pattern ensure-regex
+  "Takes a string x and turns it into a java.util.regex.Pattern. Throws an
+  exception with a meaningful message if the string doesn't represent a valid
+  Java regex."
+  [^IPersistentVector path ^String x]
+  (try
+    (re-pattern x)
+    (catch java.util.regex.PatternSyntaxException e
+      (throw (ex-info (format "Invalid regex %s at %s - %s" x (print-str path) (.getMessage e))
+                      {:path path :value x})))))
+
+(defn- transform-values
+  "Transforms some manifest values into higher level objects."
+  [^IPersistentMap manifest]
+  (-> manifest
+      (update ::v1/app-root (partial ensure-file {:absolute true} ::v1/app-root))
+      (update ::v1/source-paths #(into #{} (map (partial ensure-file {:canonicalize true, :directory true, :exists true} ::v1/source-paths) %)))
+      (update ::v1/resource-paths #(into #{} (map (partial ensure-file {:canonicalize true, :directory true, :exists true} ::v1/resource-paths) %)))
+      (update ::v1/extra-paths #(mapv (fn [{:keys [from, to] :as copyable}]
+                                        (assoc copyable :from (ensure-file {:canonicalize true, :exists true} [::v1/extra-paths :from] from)
+                                               :to (ensure-file {:absolute true} [::v1/extra-paths :to] to)))
+                                      %))
+      (update ::v1/classifiers #(into {} (map (fn [[k v]]
+                                                [k (ensure-regex [::v1/classifiers k] v)])
+                                              %)))))
+
+(defn ^IPersistentMap read-manifest
+  "Reads, validates and parses a Vessel manifest.
+
+  Manifests are regular EDN files containing various attributes that control how
+  Vessel will containerize a Clojure application. The manifest structure is
+  defined by the spec :vessel.v1/manifest."
+  ([^File manifest]
+   (read-manifest manifest {}))
+  ([^File manifest ^IPersistentMap build-time-variables]
+   (-> (misc/read-edn manifest)
+       validate-with-spec
+       (expand-all-variables build-time-variables)
+       merge-defaults
+       transform-values)))

--- a/src/vessel/v1.clj
+++ b/src/vessel/v1.clj
@@ -7,13 +7,40 @@
 
 ;; Manifest (e.g. vessel.edn).
 
-(s/def ::source-paths (s/coll-of string? :kind set? :min-count 1))
+(s/def ::from string?)
+
+(s/def ::target string?)
+
+(s/def ::app-root string?)
+
+(s/def ::app-type #{:jar :war})
+
+(s/def ::main-ns symbol?)
 
 (s/def ::resource-paths (s/coll-of string? :kind set?))
 
+(s/def ::source-paths (s/coll-of string? :kind set? :min-count 1))
+
+(s/def :copy/from string?)
+
+(s/def :copy/to string?)
+
+(s/def :copy/preserve-permissions boolean?)
+
+(s/def ::extra-paths (s/coll-of
+                      (s/keys :req-un [:copy/from :copy/to]
+                              :opt-un [:copy/preserve-permissions])
+                      :min-count 1))
+
+(s/def ::classifiers (s/map-of keyword? string? :min-count 1))
+
+(s/def ::labels (s/map-of string? string?))
+
+(s/def ::user string?)
+
 (s/def ::manifest (s/keys
-                   :req [::source-paths]
-                   :opt [::resource-paths]))
+                   :req [::from ::target ::main-ns ::source-paths]
+                   :opt [::app-root ::app-type ::resource-paths ::extra-paths  ::classifiers ::labels ::user]))
 
 ;; Classpath resolution.
 

--- a/test/unit/vessel/misc_test.clj
+++ b/test/unit/vessel/misc_test.clj
@@ -92,12 +92,12 @@
   (testing "prints or omits the message depending on the value bound to
   *verbose-logs* and the supplied log level"
     (are [verbose? stream level result]
-         (= result
-            (let [writer (java.io.StringWriter.)]
-              (binding [misc/*verbose-logs* verbose?
-                        stream writer]
-                (misc/log* level "me" "Hello!")
-                (str writer))))
+        (= result
+           (let [writer (java.io.StringWriter.)]
+             (binding [misc/*verbose-logs* verbose?
+                       stream writer]
+               (misc/log* level "me" "Hello!")
+               (str writer))))
       true  *out* :info  "INFO [me] Hello!\n"
       true  *out* "info" "INFO [me] Hello!\n"
       true  *out* :debug "DEBUG [me] Hello!\n"
@@ -122,14 +122,26 @@
              (binding [misc/*verbose-logs* true]
                (misc/log :info "Hello %s!" "John Doe")))))))
 
-(def cwd (io/file (.getCanonicalPath (io/file "."))))
+(def cwd (misc/canonicalize-file (io/file ".")))
+
+(deftest file-exists?-test
+  (is (misc/file-exists? (io/file "deps.edn"))))
+
+(deftest file?-test
+  (is (misc/file? (io/file "deps.edn"))))
+
+(deftest directory?-test
+  (is (misc/directory? (io/file "src"))))
+
+(deftest absolute-file?-test
+  (is (misc/absolute-file? cwd)))
 
 (deftest filter-files-test
-  (is (every? #(.isFile %)
+  (is (every? #(misc/file? %)
               (misc/filter-files (file-seq cwd)))))
 
 (deftest home-dir-test
-  (is (true? (misc/file-exists? (misc/home-dir)))))
+  (is (misc/file-exists? (misc/home-dir))))
 
 (deftest last-modified-time-test
   (is (instance? Instant

--- a/test/unit/vessel/reader_test.clj
+++ b/test/unit/vessel/reader_test.clj
@@ -1,0 +1,186 @@
+(ns vessel.reader-test
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer :all]
+            [matcher-combinators.test :refer [match?]]
+            [mockfn.macros :refer [calling providing]]
+            [vessel.misc :as misc]
+            [vessel.reader :as reader]
+            [vessel.v1 :as v1]))
+
+(deftest expand-variable-test
+  (testing "replaces variables with values supplied in the build-time variables map"
+    (are [s build-time-variables result]
+         (is (= result (#'reader/expand-variable s build-time-variables)))
+      "word"                   {}                                "word"         ;; just keep the input
+      "{{}}"                   {}                                "{{}}"         ;; keep the input too
+      "{{word}}"               {:word "hello"}                   "hello"
+      "Hello {{word}}!"        {:word "world"}                   "Hello world!" ;; interpolate properly
+      "{{word-1}} {{word-2}}!" {:word-1 "Hello" :word-2 "world"} "Hello world!" ;; multiple variables
+      "{{word|default}}"       {}                                "default"      ;; use the default value
+      "{{ word  |  default}}"  {:word "hello"}                   "hello"
+      "{{ word  |  default}}"  {}                                "default"))
+
+  (testing "throws an exception when there is no a matching value for the
+  variable in the build-time-variables map"
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (#'reader/expand-variable "{{word}}" {})))))
+
+(def base-image "openjdk11:alpine")
+
+(def target-image "nubank/clj-tool:v1.0.0")
+(deftest expand-all-variables-test
+  (testing "expands variables declared in the manifest and keeps other values
+  untouched"
+    (is (= #::v1{:from         base-image
+                 :target       target-image
+                 :app-root     "/nubank/clj-tool"
+                 :main-ns      'nubank.clj-tool.executor
+                 :source-paths #{"src"}}
+           (#'reader/expand-all-variables #::v1{:from         "{{base-image | openjdk11:alpine}}"
+                                                :target       "nubank/clj-tool:{{tag}}"
+                                                :app-root     "/nubank/clj-tool"
+                                                :main-ns      'nubank.clj-tool.executor
+                                                :source-paths #{"src"}}
+                                          {:tag "v1.0.0"}))))
+
+  (testing "certain keys can't be expanded"
+    (let [manifest #::v1 {:from           base-image
+                          :target         target-image
+                          :app-root       "{{app-root}}"
+                          :main-ns        'nubank.clj-tool.executor
+                          :source-paths   #{"{{src}}"}
+                          :resource-paths #{"{{resources}}"}
+                          :classifiers    {:nubank-libs "{{regex}}"}}]
+
+      (is (= manifest
+             (#'reader/expand-all-variables manifest
+                                            {:app-root  "nubank/clj-tool"
+                                             :src       "src"
+                                             :resources "resources"
+                                             :regex     ".*"}))))))
+
+(deftest merge-defaults-test
+  (testing "merges default values into the provided manifest"
+    (is (= #::v1{:from           base-image
+                 :target         target-image
+                 :app-root       "/nubank/clj-tool"
+                 :app-type       :jar
+                 :source-paths   #{"src"}
+                 :resource-paths #{}
+                 :main-ns        'nubank.clj-tool.executor}
+           (#'reader/merge-defaults #::v1{:from         base-image
+                                          :target       target-image
+                                          :source-paths #{"src"}
+                                          :main-ns      'nubank.clj-tool.executor}))))
+
+  (testing "do not override provided values"
+    (let [manifest #::v1 {:from           base-image
+                          :target         target-image
+                          :app-root       "/opt/clj-tool"
+                          :app-type       :jar
+                          :source-paths   #{"src"}
+                          :resource-paths #{"resources"}
+                          :main-ns        'nubank.clj-tool.executor}]
+      (is (= manifest (#'reader/merge-defaults manifest))))))
+
+(def manifest #::v1{:from           base-image
+                    :target         target-image
+                    :source-paths   #{"src"}
+                    :resource-paths #{"resources"}
+                    :extra-paths    [{:from "scripts/clj-tool.sh"
+                                      :to   "/usr/local/bin/clj-tool"}]
+                    :main-ns        'nubank.clj-tool.executor
+                    :classifiers    {:nubank-libs "nubank"}})
+
+(deftest read-manifest-test
+  (let [manifest-file (io/file "vessel.edn")]
+    (providing [(misc/read-edn manifest-file) manifest
+                (misc/file-exists? (io/file "src")) true
+                (misc/file-exists? (io/file "resources")) true
+                (misc/directory? (io/file "src")) true
+                (misc/directory? (io/file "resources")) true
+                (misc/file-exists? (io/file "scripts/clj-tool.sh")) true
+                (misc/canonicalize-file (partial instance? java.io.File)) (calling #(io/file "/workspace" %))]
+
+               (testing "returns a processed manifest map"
+                 (is (match? #::v1{:from         base-image
+                                   :target       target-image
+                                   :app-root     (io/file "/nubank/clj-tool") ;; derived from :main-ns
+                                   :app-type     :jar
+                                   :main-ns      'nubank.clj-tool.executor
+                                   :source-paths #{(io/file "/workspace/src")}
+                                   :resource-paths
+                                   #{(io/file "/workspace/resources")}
+                                   :extra-paths
+                                   [{:from
+                                     (io/file "/workspace/scripts/clj-tool.sh")
+                                     :to (io/file "/usr/local/bin/clj-tool")}]
+                                   :classifiers  {:nubank-libs (partial instance? java.util.regex.Pattern)}}
+                             (reader/read-manifest manifest-file))))
+
+               (testing "expands variables by using supplied build-time-variables"
+                 (providing [(misc/read-edn manifest-file)
+                             (assoc manifest ::v1/labels {"org.label-schema.vcs-ref" "{{git-sha}}"})]
+                            (is (match? #::v1{:labels
+                                              {"org.label-schema.vcs-ref" "64aa7fc"}}
+                                        (reader/read-manifest manifest-file
+                                                              {:git-sha "64aa7fc"})))))
+
+               (testing "throws an exception when the manifest doesn't conform to the spec :vessel.v1/manifest"
+                 (providing [(misc/read-edn (io/file "vessel.edn"))
+                             #::v1{:target target-image}]
+                            (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                                  #"^Invalid manifest. See further details about the violations below"
+                                                  (reader/read-manifest manifest-file)))))
+
+               (testing "the app root must be an absolute path"
+                 (providing [(misc/read-edn manifest-file)
+                             (assoc manifest ::v1/app-root "clj-tool")]
+                            (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                                  #"Invalid path at :vessel.v1/app-root - \"clj-tool\" isn't an absolute path\."
+                                                  (reader/read-manifest manifest-file)))))
+
+               (testing "source paths must be existent directories"
+                 (providing [(misc/file-exists? (io/file "src")) false]
+                            (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                                  #"Invalid path at :vessel.v1/source-paths - no such file or directory: \"src\"\."
+                                                  (reader/read-manifest manifest-file))))
+
+                 (providing [(misc/directory? (io/file "src")) false]
+                            (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                                  #"Invalid path at :vessel.v1/source-paths - \"src\" isn't a directory\."
+                                                  (reader/read-manifest manifest-file)))))
+
+               (testing "resource paths must be existent directories"
+                 (providing [(misc/file-exists? (io/file "src")) true
+                             (misc/file-exists? (io/file "resources")) false]
+                            (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                                  #"Invalid path at :vessel.v1/resource-paths - no such file or directory: \"resources\"\."
+                                                  (reader/read-manifest manifest-file))))
+
+                 (providing [(misc/directory? (io/file "src")) true
+                             (misc/directory? (io/file "resources")) false]
+                            (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                                  #"Invalid path at :vessel.v1/resource-paths - \"resources\" isn't a directory\."
+                                                  (reader/read-manifest manifest-file)))))
+
+               (testing "the :from value of extra-paths must be an existent file"
+                 (providing [(misc/file-exists? (io/file "src")) true
+                             (misc/file-exists? (io/file "resources")) true
+                             (misc/file-exists? (io/file "scripts/clj-tool.sh")) false]
+                            (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                                  #"Invalid path at \[:vessel.v1/extra-paths :from\] - no such file or directory: \"scripts/clj-tool.sh\"\."
+                                                  (reader/read-manifest manifest-file)))))
+
+               (testing "the :to value of extra-paths must refer to an absolute path"
+                 (providing [(misc/read-edn manifest-file)
+                             (update-in manifest [::v1/extra-paths 0 :to] (constantly "scripts/clj-tool.sh"))]
+                            (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                                  #"Invalid path at \[:vessel.v1/extra-paths :to\] - \"scripts/clj-tool.sh\" isn't an absolute path\." (reader/read-manifest manifest-file)))))
+
+               (testing "classifiers must contain valid regexes"
+                 (providing [(misc/read-edn manifest-file)
+                             (update-in manifest [::v1/classifiers :nubank-libs] (constantly "*"))]
+                            (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                                  #"Invalid regex \* at \[:vessel.v1/classifiers :nubank-libs\]"
+                                                  (reader/read-manifest manifest-file))))))))


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] There is an open issue describing the problem that this pr intents to solve.
    - [x] You have a descriptive commit message with a short title (first line).
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?**

N/A

* **What is the new behavior (if this is a feature change)?**

This pull request creates a reader for Vessel manifests. This manifest is an EDN
file containing various attributes that will be used by the new container
builder, that is under development, to create the build plan and to containerize
the application.

The reader reads, processes the manifest and perform a set of validations
showing descriptive messages to the user when something is mistakenly declared.

The main goal is move Vessel towards a more declarative approach through those
EDN manifests. One of the current pitfalls of Vessel is that the CLI is
extremely hard to use and users need to pass a bunch of flags to build an
application. With the introduction of manifests, just one flag will be needed to
point to the manifest. A basic manifest just requires four keys: fro`:from`,
`:target`, `:source-paths` and `:main-ns`.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**: