### PR TITLE
Preserve timestamps when copying files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Preserve timestamps when copying files:
+  [#21](https://github.com/nubank/vessel/pull/21). The corresponding issue was
+  slowing down the startup of containerized applications and causing runtime
+  problems due to conflicts between AOT and JIT compiled Clojure namespaces.
+
 ## [0.2.134] - 2020-07-03
 
 ### Added

--- a/test/unit/vessel/builder_test.clj
+++ b/test/unit/vessel/builder_test.clj
@@ -69,7 +69,11 @@
              (misc/read-edn (io/file target "classes/data_readers.clj"))))
       (is (= {'lib3/date 'lib3.date/string->local-date
               'lib4/usd  'lib4.money/bigdec->money}
-             (misc/read-edn (io/file target "classes/data_readers.cljc")))))))
+             (misc/read-edn (io/file target "classes/data_readers.cljc")))))
+
+    (testing "preserve timestamps when copying files"
+      (is (=              (.lastModified (io/file src "lib1/resource1.edn"))
+                          (.lastModified (io/file target "classes/resource1.edn")))))))
 
 (defn get-file-names
   [^File dir]
@@ -111,7 +115,7 @@
              (set (misc/filter-files (file-seq (io/file target "WEB-INF/lib")))))))
 
     ;; TODO: uncomment after fixing https://github.com/nubank/vessel/issues/7.
-    #_ (testing "throws an exception describing the underwing compilation error"
+    #_(testing "throws an exception describing the underwing compilation error"
         (is (thrown-match? clojure.lang.ExceptionInfo
                            #:vessel.error{:category :vessel/compilation-error}
                            (builder/build-app (assoc options :main-class 'my-app.compilation-error)))))))


### PR DESCRIPTION
Closes #20

* **Please check if the PR fulfills these requirements**
- [x] There is an open issue describing the problem that this pr intents to solve.
    - [x] You have a descriptive commit message with a short title (first line).
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix.

* **What is the current behavior?**

When building the Clojure project, Vessel copies files from jar files and
directories on the classpath without preserving their original timestamp. This
was introducing several issues such as slowing down the startup time of
containerized applications as well as creating conflicts between AOT and JIT
compiled namespaces.

* **What is the new behavior (if this is a feature change)?**

Vessel now preserves the last modified time of copied files. Thus, the Clojure
loader can recognize properly what is the newest version of a file - .class or
clj(c) - to be loaded.
clj(c) file t

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**: