### PR TITLE
Copy non-mapped files to the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Avoid blowing up the build process when a non-mapped class file is found [#22](https://github.com/nubank/vessel/pull/22). Now, the non-mapped file is assigned to the first known source directory in order to force the file to be copied to the corresponding image layer.
+
 ## [0.2.135] - 2020-08-10
 
 ### Fixed

--- a/test/unit/vessel/builder_test.clj
+++ b/test/unit/vessel/builder_test.clj
@@ -24,11 +24,7 @@
         "clj_tuple$fn__18034.class"           "clj-tuple.jar"
         "zookeeper$host_acl.class"            "zookeeper-clj.jar"
         "zookeeper$set_data$fn__54225.class"  "zookeeper-clj.jar"
-        "zookeeper__init.class"               "zookeeper-clj.jar"))
-
-    (testing "throws an exception when the source can't be found"
-      (is (thrown? IllegalStateException
-                   (builder/get-class-file-source namespace (io/file "clojure/zip$zipper.class")))))))
+        "zookeeper__init.class"               "zookeeper-clj.jar"))))
 
 (deftest copy-files-test
   (let [src    (io/file "test/resources")
@@ -84,6 +80,7 @@
         target          (io/file "target/tests/builder-test/build-app-test")
         classpath-files (set (map io/file (string/split (classpath project-dir) #":")))
         options         {:classpath-files classpath-files
+                         :source-paths  #{(io/file project-dir "src")}
                          :resource-paths  #{(io/file project-dir "resources")}
                          :target-dir      target}
         output          (builder/build-app (assoc options :main-class 'my-app.server))]


### PR DESCRIPTION
Under some circumstances the Clojure compiler creates class files that start
with the prefix null$. I haven't yet understood what are those circumstances,
but those classes don't map directly to known namespaces what breaks the
algorithm that Vessel uses to infer the relations between compiled classes and
their sources.

Previously, I was throwing an exception when that behavior happened (as a save
guard). Since the algorithm has been tested in many scenarios and looks like
correct, now I'm changing the behavior to default to the first known source path
when a given class file can't be mapped to a known source.


* **Please check if the PR fulfills these requirements**
- [ ] There is an open issue describing the problem that this pr intents to solve.
    - [x] You have a descriptive commit message with a short title (first line).
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix.

* **What is the current behavior?**

Vessel throws an exception when can't map a compiled class file to a known
namespace on the classpath.

* **What is the new behavior (if this is a feature change)?**

Vessel defaults the non-mapped class file to one of the source directories to
force the file in question to be copied to the corresponding layer.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**: