### PR TITLE
Preserve order of classpath entries to avoid conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Accept tarballs as base images: [#23](https://github.com/nubank/vessel/pull/23). This feature will be less obscure and easier to be used in the version 1 of Vessel.
 
+### Fixed
+- Preserve the order of classpath entries to avoid introducing conflicts: [#24](https://github.com/nubank/vessel/pull/24).
+
 ## [0.2.137] - 2020-12-07
 
 ### Fixed

--- a/src/vessel/builder.clj
+++ b/src/vessel/builder.clj
@@ -218,7 +218,7 @@
 
   The options map expects the following keys:
 
-  * :classpath-files (set of java.io.File objects) representing the
+  * :classpath-files (seq of java.io.File objects) representing the
   classpath of the Clojure application;
   * :main-class (symbol) application entrypoint containing
   a :gen-class directive and a -main function;
@@ -238,7 +238,7 @@
   (let [web-inf        (misc/make-dir target-dir "WEB-INF")
         classes        (compile classpath-files main-class source-paths web-inf)
         dirs+jar-files (set/union resource-paths (set (vals classes)))
-        libs           (misc/filter-files (set/difference classpath-files dirs+jar-files))
+        libs           (misc/filter-files (set/difference (set classpath-files) dirs+jar-files))
         resource-files (copy-files dirs+jar-files web-inf)]
     #:app{:classes (merge classes resource-files)
           :lib     (copy-libs libs web-inf)}))

--- a/src/vessel/program.clj
+++ b/src/vessel/program.clj
@@ -33,7 +33,7 @@
             ["-c" "--classpath PATHS"
              :id :classpath-files
              :desc "Directories and zip/jar files on the classpath in the same format expected by the java command"
-             :parse-fn (comp set (partial map io/file) #(string/split % #":"))]
+             :parse-fn (comp (partial map io/file) #(string/split % #":"))]
             ["-e" "--extra-path PATH"
              :id :extra-paths
              :desc "extra files to be copied to the container image. The value must be passed in the form source:target or source:target@churn and this option can be repeated many times"

--- a/test/unit/vessel/builder_test.clj
+++ b/test/unit/vessel/builder_test.clj
@@ -78,9 +78,9 @@
 (deftest build-app-test
   (let [project-dir     (io/file "test/resources/my-app")
         target          (io/file "target/tests/builder-test/build-app-test")
-        classpath-files (set (map io/file (string/split (classpath project-dir) #":")))
+        classpath-files (map io/file (string/split (classpath project-dir) #":"))
         options         {:classpath-files classpath-files
-                         :source-paths  #{(io/file project-dir "src")}
+                         :source-paths    #{(io/file project-dir "src")}
                          :resource-paths  #{(io/file project-dir "resources")}
                          :target-dir      target}
         output          (builder/build-app (assoc options :main-class 'my-app.server))]


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] There is an open issue describing the problem that this pr intents to solve.
    - [ ] You have a descriptive commit message with a short title (first line).
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.

* **What is the current behavior?**

Vessel uses a persistent set internally to represent classpath entries. This bad
decision may cause classpath conflicts in very specific situations due to
changes in the order of those entries.

* **What is the new behavior (if this is a feature change)?**

Preserve the order of classpath entries by storing them in a sequence rather
than in a set.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**: