### PR TITLE
Support reader conditional when reading/merging data_readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Use the newly created function misc/read-data to read/merge data_readers instead of the misc/read-edn function. The former preserves reader conditionals [#31](https://github.com/nubank/vessel/pull/31).
+
 ## [0.2.146] - 2023-08-10
 
 - Resources with the extension `.edn` are deep merged together: [#29](https://github.com/nubank/vessel/pull/29).

--- a/src/vessel/misc.clj
+++ b/src/vessel/misc.clj
@@ -175,6 +175,18 @@
   [input]
   (edn/read-string (slurp input)))
 
+(defn read-data
+  "Reads one object from the provided input.
+
+  input can be any object supported by clojure.core/slurp.
+
+  Note: this function is meant to be used to parse objects from
+  data_readers files."
+  [input]
+  (binding [*read-eval* false]
+    (read-string {:read-cond :preserve :features #{:clj}}
+                 (slurp input))))
+
 (defn read-json
   "Reads a JSON object and parses it as Clojure data.
 

--- a/src/vessel/resource_merge.clj
+++ b/src/vessel/resource_merge.clj
@@ -35,7 +35,7 @@
   data_readers.clj/cljc - merged together
   *.edn - deep merged together"
   [{:match-fn #(re-find #"/data_readers.cljc?$" (.getPath ^File %))
-    :read-fn  misc/read-edn
+    :read-fn  misc/read-data
     :merge-fn merge
     :write-fn write-edn}
    {:match-fn #(.endsWith ".edn" (.getPath ^File %))
@@ -104,4 +104,3 @@
         (assoc result target-file classpath-root)))
     {}
     (-> merge-set ::*merged-paths deref)))
-

--- a/test/unit/vessel/misc_test.clj
+++ b/test/unit/vessel/misc_test.clj
@@ -153,6 +153,11 @@
   (is (= {:greeting "Hello!"}
          (misc/read-edn (StringReader. "{:greeting \"Hello!\"}")))))
 
+(deftest read-data-test
+  (is (= {'x (reader-conditional '(:clj foo.bar/x-clj :cljs foo.bar/x-cljs) false)}
+         (misc/read-data
+          (StringReader. "{x #?(:clj foo.bar/x-clj :cljs foo.bar/x-cljs)}")))))
+
 (deftest read-json-test
   (is (= {:greeting "Hello!"}
          (misc/read-json (StringReader. "{\"greeting\" : \"Hello!\"}")))))


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

* **Please check if the PR fulfills these requirements**
- [ ] There is an open issue describing the problem that this pr intents to solve.
    - [ ] You have a descriptive commit message with a short title (first line).
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?**

When Vessel encounters a data_reader file containing reader conditionals, a
runtime exception (no dispatch macro for ?) is thrown.


* **What is the new behavior (if this is a feature change)?**

As of this pull request Vessel reads data_readers files containing reader
conditionals properly.



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No


* **Other information**: