### PR TITLE
Fix deep-merge for edn files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fix the logic in the function that checks if a file ends with `.edn`: [#36](https://github.com/nubank/vessel/pull/36).
+
 ## [0.2.152] - 2024-02-01
 
 ## [0.2.151] - 2024-02-01

--- a/src/vessel/resource_merge.clj
+++ b/src/vessel/resource_merge.clj
@@ -20,6 +20,9 @@
     (sequential? left)
     (into left right)
 
+    (set? left)
+    (into left right)
+
     :else
     right))
 
@@ -38,7 +41,7 @@
     :read-fn  misc/read-data
     :merge-fn merge
     :write-fn write-edn}
-   {:match-fn #(.endsWith ".edn" (.getPath ^File %))
+   {:match-fn #(.endsWith (.getPath ^File %) ".edn")
     :read-fn  misc/read-edn
     :merge-fn deep-merge
     :write-fn write-edn}])

--- a/src/vessel/resource_merge.clj
+++ b/src/vessel/resource_merge.clj
@@ -32,19 +32,23 @@
 ;; :merge-fn (fn [old-value, new-value]) -> merged-value
 ;; :write-fn (fn [File, value]) -> nil (but writes the merged value)
 
-(def base-rules
-  "Basic rules:
+(def data-readers-base-rule
+  "data_raders.clj/cljc - merged together"
+  {:match-fn #(re-find #"/data_readers.cljc?$" (.getPath ^File %))
+   :read-fn  misc/read-data
+   :merge-fn merge
+   :write-fn write-edn})
 
-  data_readers.clj/cljc - merged together
-  *.edn - deep merged together"
-  [{:match-fn #(re-find #"/data_readers.cljc?$" (.getPath ^File %))
-    :read-fn  misc/read-data
-    :merge-fn merge
-    :write-fn write-edn}
-   {:match-fn #(.endsWith (.getPath ^File %) ".edn")
-    :read-fn  misc/read-edn
-    :merge-fn deep-merge
-    :write-fn write-edn}])
+(def edn-base-rule
+  "*.edn - deep merged together"
+  {:match-fn #(.endsWith (.getPath ^File %) ".edn")
+   :read-fn  misc/read-edn
+   :merge-fn deep-merge
+   :write-fn write-edn})
+
+(def base-rules
+  [data-readers-base-rule
+   edn-base-rule])
 
 (defn new-merge-set
   "Creates a new merge set, with the provided rules (or [[base-rules]] as a default).
@@ -75,15 +79,19 @@
                                                 :last-modified  last-modified
                                                 :value          new-value}))))))
 
+(defn find-matching-rule
+  [rules file]
+  (some (fn [rule]
+          (when ((:match-fn rule) file)
+            rule))
+        rules))
+
 (defn execute-merge-rules
   "Evaluates the inputs against the rules in the provided merge set.  Returns true
   if the file is subject to a merge rule (in which case, it should not be simply copied)."
   [classpath-root input-stream target-file last-modified merge-set]
   (let [{::keys [rules]} merge-set
-        matched-rule (some (fn [rule]
-                             (when ((:match-fn rule) target-file)
-                               rule))
-                           rules)]
+        matched-rule (find-matching-rule rules target-file)]
     (if matched-rule
       (do
         (apply-rule classpath-root input-stream target-file last-modified matched-rule merge-set)

--- a/test/resources/lib1/resource1.edn
+++ b/test/resources/lib1/resource1.edn
@@ -1,2 +1,6 @@
-{:list [1 2 3]
- :map {:a 1}}
+{:list     [1 2 3 4]
+ :map      {:a 1
+            :c 4}
+ :set      #{1 2}
+ :old-key  4
+ :same-key :old-value}

--- a/test/resources/lib2/resource1.edn
+++ b/test/resources/lib2/resource1.edn
@@ -1,4 +1,6 @@
-{:list [1 2 3]
- :map {:a 2
-       :b 3}
- :new-key 4}
+{:list     [4 5 6]
+ :map      {:a 2
+            :b 3}
+ :set      #{1 3}
+ :new-key  4
+ :same-key :new-value}

--- a/test/unit/vessel/builder_test.clj
+++ b/test/unit/vessel/builder_test.clj
@@ -61,10 +61,14 @@
 
     (testing "edn files are merged"
       ;; This is the deep merge of the two copies of resource1:
-      (is (= {:list    [1 2 3]
-              :map     {:a 2
-                        :b 3}
-              :new-key 4}
+      (is (= {:list     [1 2 3 4 4 5 6]
+              :map      {:a 2
+                         :b 3
+                         :c 4}
+              :set      #{1 2 3}
+              :old-key  4
+              :new-key  4
+              :same-key :new-value}
              (-> (io/file target "classes/resource1.edn")
                  misc/read-edn))))
 

--- a/test/unit/vessel/resource_merge_test.clj
+++ b/test/unit/vessel/resource_merge_test.clj
@@ -1,0 +1,38 @@
+(ns vessel.resource-merge-test
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is testing]]
+            [vessel.resource-merge :as merge]))
+
+(deftest find-matching-rule-test
+  (let [data-readers-file (io/file "test/resources/lib1/data_readers.clj")
+        edn-file          (io/file "test/resources/lib1/resource1.edn")]
+    (testing "if rules are empty, it returns nil"
+      (is (nil? (merge/find-matching-rule [] edn-file))))
+
+    (testing "if no rules match, it returns nil"
+      (let [rule {:match-fn (constantly false)
+                  :read-fn  (constantly "rule")
+                  :merge-fn (constantly "rule")
+                  :write-fn (constantly "rule")}]
+        (is (nil? (merge/find-matching-rule [rule] edn-file)))))
+
+    (testing "if multiple rules match, it returns the first one"
+      (let [first-rule  {:match-fn (constantly true)
+                         :read-fn  (constantly "first-rule")
+                         :merge-fn (constantly "first-rule")
+                         :write-fn (constantly "first-rule")}
+            second-rule {:match-fn (constantly true)
+                         :read-fn  (constantly "second-rule")
+                         :merge-fn (constantly "second-rule")
+                         :write-fn (constantly "second-rule")}]
+        (is (= first-rule
+               (merge/find-matching-rule [first-rule second-rule] edn-file)))))
+
+    (testing "with base-rules"
+      (testing "if file matches data_readers pattern, it returns the data-readers-base-rule"
+        (is (= merge/data-readers-base-rule
+               (merge/find-matching-rule merge/base-rules data-readers-file))))
+
+      (testing "if file ends with .edn, it returns the edn-base-rule"
+        (is (= merge/edn-base-rule
+               (merge/find-matching-rule merge/base-rules edn-file)))))))


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

* **Please check if the PR fulfills these requirements**
- [x] There is an open issue describing the problem that this pr intents to solve.
    - [x] You have a descriptive commit message with a short title (first line).
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added / updated (for bug fixes / features).

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR fixes a bug in the function that checks if a file path ends with `.edn` which is used to decide if the file will be merged.

The actual function has its arguments reversed:
```clj
#(.endsWith ".edn" (.getPath ^File %)) ;; Current
#(.endsWith (.getPath ^File %) ".edn") ;; New
```

* **What is the current behavior?**
The `.edn` files are not deep-merged during the build due to a bug in the function that checks if the file path ends with `.edn`.


* **What is the new behavior (if this is a feature change)?**
Not a new behavior, just fixing the logic to deep-merge `.edn` files.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking changes.



* **Other information**:
Relates with: https://github.com/nubank/vessel/issues/35
