### PR TITLE
Handle reader macros when merging EDN files

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses:       actions/checkout@v2
+      uses:       actions/checkout@v4
 
     - name: Cache Maven deps
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       env:
         cache-name: maven-deps
       with:
@@ -46,10 +46,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses:       actions/checkout@v2
+      uses:       actions/checkout@v4
 
     - name: Cache Maven deps
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       env:
         cache-name: maven-deps
       with:

--- a/test/resources/lib5/with-reader-macros.edn
+++ b/test/resources/lib5/with-reader-macros.edn
@@ -1,0 +1,2 @@
+{:k1 :v2
+ :k2 #unknown/macro :v2}

--- a/test/resources/lib6/with-reader-macros.edn
+++ b/test/resources/lib6/with-reader-macros.edn
@@ -1,0 +1,2 @@
+{:k1 :override-k1
+ :k3 #weird/macro :v3}

--- a/test/unit/vessel/builder_test.clj
+++ b/test/unit/vessel/builder_test.clj
@@ -90,6 +90,17 @@
       (is (= (.lastModified (io/file src "lib2/resource1.edn"))
              (.lastModified (io/file target "classes/resource1.edn")))))))
 
+(deftest merge-with-reader-macros
+  (let [src    (io/file "test/resources")
+        target (io/file "target/tests/builder-test/reader-macros")
+        _      (builder/copy-files #{(io/file src "lib5")
+                                     (io/file src "lib6")}
+                                   target)]
+
+    (testing "edn files with reader macros are merged"
+      (is (= (slurp (io/file target "classes" "with-reader-macros.edn"))
+             "{:k1 :override-k1, :k2 #unknown/macro :v2, :k3 #weird/macro :v3}")))))
+
 (defn get-file-names
   [^File dir]
   (map #(.getName %) (.listFiles dir)))


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

* **Please check if the PR fulfills these requirements**
- [ x] There is an open issue describing the problem that this pr intents to solve.
    - [ x] You have a descriptive commit message with a short title (first line).
- [ x] Tests for the changes have been added (for bug fixes / features).
- [ x] Docs have been added / updated (for bug fixes / features).

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the current behavior?**

The tool throws an exception when attempting to merge EDN files containing undefined reader macros.

* **What is the new behavior (if this is a feature change)?**

The EDN files are merged, and reader macros are maintained (via clojure.core/tagged-literal).

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.



