### PR TITLE
Detect and report errors reading mergeable sources

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -7,8 +7,7 @@
   org.clojure/tools.cli #:mvn{:version "0.4.2"}
   org.clojure/tools.namespace #:mvn{:version "0.3.1"}
   com.cognitect.aws/ecr #:mvn{:version "798.2.678.0"}
-  progrock #:mvn{:version "0.1.2"}
-  clj-commons/spinner #:mvn{:version "0.6.0"}
+  progrock/progrock #:mvn{:version "0.1.2"}
   com.google.cloud.tools/jib-core #:mvn{:version "0.13.0"}
   org.clojure/core.async #:mvn{:version "1.0.567"}}
  :aliases
@@ -17,8 +16,10 @@
    :extra-deps
    {cognitect/test-runner
     {:git/url "https://github.com/cognitect-labs/test-runner.git"
-     :sha "cb96e80f6f3d3b307c59cbeb49bb0dcb3a2a780b"}
-    org.clojure/test.check #:mvn{:version "0.10.0-RC1"}
-    nubank/mockfn #:mvn{:version "0.6.1"}
+     :sha     "cb96e80f6f3d3b307c59cbeb49bb0dcb3a2a780b"}
+    org.clojure/test.check          #:mvn{:version "0.10.0-RC1"}
+    nubank/mockfn                   #:mvn{:version "0.6.1"}
     org.apache.commons/commons-vfs2 #:mvn{:version "2.4.1"}
-    nubank/matcher-combinators #:mvn{:version "1.2.5"}}}}}
+    babashka/fs                     {:mvn/version "0.5.22"}
+    io.github.tonsky/clj-reload     {:mvn/version "0.7.1"}
+    nubank/matcher-combinators      #:mvn{:version "3.9.1"}}}}}

--- a/src/vessel/resource_merge.clj
+++ b/src/vessel/resource_merge.clj
@@ -108,7 +108,7 @@
   "Evaluates the inputs against the rules in the provided merge set.  Returns true
   if the file is subject to a merge rule (in which case, it should not be simply copied).
 
-  classpath-root - root of classpath; a File that is either a director or a Jar file
+  classpath-root - origin of the input, a File; either a directory or a JAR file
   input-source - string describing where the input-stream comes from
   input-stream - InputStream containing content of the file
   target-file - File to write from the input stream (or merged)

--- a/src/vessel/resource_merge.clj
+++ b/src/vessel/resource_merge.clj
@@ -70,11 +70,20 @@
     ::*merged-paths (atom {})}))
 
 (defn- apply-rule
-  [classpath-root ^InputStream input-stream target-file last-modified rule merge-set]
+  [classpath-root input-source ^InputStream input-stream target-file last-modified rule merge-set]
   (let [{::keys [*merged-paths]} merge-set
         {:keys [read-fn merge-fn]} rule
-        new-value (read-fn input-stream)]
-    (.close input-stream)
+        new-value (try
+                    (read-fn input-stream)
+                    (catch Throwable t
+                      (throw (ex-info (str "Unable to read " input-source ": "
+                                           (or (ex-message t)
+                                               (-> t class .getName)))
+                                      {:classpath-root classpath-root
+                                       :input-source   input-source
+                                       :target-file    target-file})))
+                    (finally
+                      (.close input-stream)))]
     (swap! *merged-paths
            (fn [merged-paths]
              (if (contains? merged-paths target-file)
@@ -97,13 +106,20 @@
 
 (defn execute-merge-rules
   "Evaluates the inputs against the rules in the provided merge set.  Returns true
-  if the file is subject to a merge rule (in which case, it should not be simply copied)."
-  [classpath-root input-stream target-file last-modified merge-set]
+  if the file is subject to a merge rule (in which case, it should not be simply copied).
+
+  classpath-root - root of classpath; a File that is either a director or a Jar file
+  input-source - string describing where the input-stream comes from
+  input-stream - InputStream containing content of the file
+  target-file - File to write from the input stream (or merged)
+  last-modified - timestamp of last modified time to be applied to the final output
+  merge-set - mutable object containing details about merging"
+  [classpath-root input-source input-stream target-file last-modified merge-set]
   (let [{::keys [rules]} merge-set
         matched-rule (find-matching-rule rules target-file)]
     (if matched-rule
       (do
-        (apply-rule classpath-root input-stream target-file last-modified matched-rule merge-set)
+        (apply-rule classpath-root input-source input-stream target-file last-modified matched-rule merge-set)
         true)
       false)))
 

--- a/test/resources/badlib/bad-input.edn
+++ b/test/resources/badlib/bad-input.edn
@@ -1,0 +1,2 @@
+{:foo :bar
+ :baz #_ :biff}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

* **Please check if the PR fulfills these requirements**
- [ x] There is an open issue describing the problem that this pr intents to solve.
    - [x ] You have a descriptive commit message with a short title (first line).
- [ x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix for https://github.com/nubank/vessel/issues/42

* **What is the current behavior?**

The original exception is reported but gives no context about what file contains the parse error.

* **What is the new behavior (if this is a feature change)?**

Catches exceptions when parsing mergeable files, and throws a new exception with details about what file was being read when the original exception occured.

Also, removed the spinner output, which makes reading log ouput harder. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Not a breaking change.


* **Other information**:
